### PR TITLE
feat: add secondary dicom server

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -77,7 +77,7 @@ module.exports = {
         '@cornerstonejs/codec-charls/decodewasmjs': '@cornerstonejs/codec-charls/dist/charlswasm_decode.js',
         '@cornerstonejs/codec-charls/decodewasm': '@cornerstonejs/codec-charls/dist/charlswasm_decode.wasm',
         '@cornerstonejs/codec-openjpeg/decodewasmjs': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.js',
-        '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm',
+        '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm'
       }
       return config
     }

--- a/public/config/local.js
+++ b/public/config/local.js
@@ -34,7 +34,7 @@ window.config = {
         fill: {
           color: [255, 255, 255, 0.2]
         }
-      },
+      }
     },
     {
       finding: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,9 @@ function _createClientMapping ({ baseUri, settings, onError }: {
     serverSettings: ServerSettings
   ) => void
 }): { [sopClassUID: string]: DicomWebManager } {
-  const storageClassMapping: { [key: string]: number } = { default: 0 }
+  const storageClassMapping: { [key: string]: number } = { default: 0 };
+  const clientMapping: { [sopClassUID: string]: DicomWebManager } = {};
+
   settings.forEach(serverSettings => {
     if (serverSettings.storageClasses != null) {
       serverSettings.storageClasses.forEach(sopClassUID => {
@@ -80,7 +82,12 @@ function _createClientMapping ({ baseUri, settings, onError }: {
         }
       })
     } else {
-      storageClassMapping.default += 1
+      storageClassMapping.default += 1;
+      clientMapping.default = new DicomWebManager({
+        baseUri,
+        settings: [serverSettings],
+        onError,
+      });
     }
   })
 
@@ -94,6 +101,7 @@ function _createClientMapping ({ baseUri, settings, onError }: {
       )
     )
   }
+
   for (const key in storageClassMapping) {
     if (key === 'default') {
       continue
@@ -111,7 +119,6 @@ function _createClientMapping ({ baseUri, settings, onError }: {
     }
   }
 
-  const clientMapping: { [sopClassUID: string]: DicomWebManager } = {}
   if (Object.keys(storageClassMapping).length > 1) {
     settings.forEach(server => {
       const client = new DicomWebManager({
@@ -125,13 +132,8 @@ function _createClientMapping ({ baseUri, settings, onError }: {
         })
       }
     })
-    clientMapping.default = clientMapping[
-      StorageClasses.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE
-    ]
-  } else {
-    const client = new DicomWebManager({ baseUri, settings, onError })
-    clientMapping.default = client
   }
+
   Object.values(StorageClasses).forEach(sopClassUID => {
     if (!(sopClassUID in clientMapping)) {
       clientMapping[sopClassUID] = clientMapping.default
@@ -229,7 +231,8 @@ class App extends React.Component<AppProps, AppState> {
 
     this.handleServerSelection = this.handleServerSelection.bind(this)
 
-    message.config({ duration: 5 })
+    message.config({ duration: 5 });
+    this.addGcpSecondaryAnnotationServer(props.config);
 
     this.state = {
       clients: _createClientMapping({
@@ -239,6 +242,33 @@ class App extends React.Component<AppProps, AppState> {
       }),
       isLoading: true,
       wasAuthSuccessful: false
+    }
+  }
+
+  addGcpSecondaryAnnotationServer(config: AppProps['config']) {
+    const serverId = 'gcp_secondary_annotation_server';
+    const urlParams = new URLSearchParams(window.location.search);
+    const gcpPath = urlParams.get("gcp");
+    const gcpSecondaryAnnotationServer = config.servers.find(
+      (server) => server.id === serverId
+    );
+    if (!gcpSecondaryAnnotationServer && gcpPath) {
+      config.servers.push({
+        id: serverId,
+        write: true,
+        url: `https://healthcare.googleapis.com/v1beta1/${gcpPath}`,
+        storageClasses: [
+          StorageClasses.COMPREHENSIVE_SR,
+          StorageClasses.COMPREHENSIVE_3D_SR,
+          StorageClasses.SEGMENTATION,
+          StorageClasses.MICROSCOPY_BULK_SIMPLE_ANNOTATION,
+          StorageClasses.PARAMETRIC_MAP,
+          StorageClasses.ADVANCED_BLENDING_PRESENTATION_STATE,
+          StorageClasses.COLOR_SOFTCOPY_PRESENTATION_STATE,
+          StorageClasses.GRAYSCALE_SOFTCOPY_PRESENTATION_STATE,
+          StorageClasses.PSEUDOCOLOR_SOFTCOPY_PRESENTATION_STATE,
+        ],
+      });
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,8 +62,8 @@ function _createClientMapping ({ baseUri, settings, onError }: {
     serverSettings: ServerSettings
   ) => void
 }): { [sopClassUID: string]: DicomWebManager } {
-  const storageClassMapping: { [key: string]: number } = { default: 0 };
-  const clientMapping: { [sopClassUID: string]: DicomWebManager } = {};
+  const storageClassMapping: { [key: string]: number } = { default: 0 }
+  const clientMapping: { [sopClassUID: string]: DicomWebManager } = {}
 
   settings.forEach(serverSettings => {
     if (serverSettings.storageClasses != null) {
@@ -82,12 +82,12 @@ function _createClientMapping ({ baseUri, settings, onError }: {
         }
       })
     } else {
-      storageClassMapping.default += 1;
+      storageClassMapping.default += 1
       clientMapping.default = new DicomWebManager({
         baseUri,
         settings: [serverSettings],
-        onError,
-      });
+        onError
+      })
     }
   })
 
@@ -231,8 +231,8 @@ class App extends React.Component<AppProps, AppState> {
 
     this.handleServerSelection = this.handleServerSelection.bind(this)
 
-    message.config({ duration: 5 });
-    this.addGcpSecondaryAnnotationServer(props.config);
+    message.config({ duration: 5 })
+    this.addGcpSecondaryAnnotationServer(props.config)
 
     this.state = {
       clients: _createClientMapping({
@@ -245,14 +245,14 @@ class App extends React.Component<AppProps, AppState> {
     }
   }
 
-  addGcpSecondaryAnnotationServer(config: AppProps['config']) {
-    const serverId = 'gcp_secondary_annotation_server';
-    const urlParams = new URLSearchParams(window.location.search);
-    const url = urlParams.get("gcp");
+  addGcpSecondaryAnnotationServer (config: AppProps['config']): void {
+    const serverId = 'gcp_secondary_annotation_server'
+    const urlParams = new URLSearchParams(window.location.search)
+    const url = urlParams.get('gcp')
     const gcpSecondaryAnnotationServer = config.servers.find(
       (server) => server.id === serverId
-    );
-    if (!gcpSecondaryAnnotationServer && url) {
+    )
+    if (gcpSecondaryAnnotationServer === undefined && typeof url === 'string') {
       config.servers.push({
         id: serverId,
         write: true,
@@ -266,9 +266,9 @@ class App extends React.Component<AppProps, AppState> {
           StorageClasses.ADVANCED_BLENDING_PRESENTATION_STATE,
           StorageClasses.COLOR_SOFTCOPY_PRESENTATION_STATE,
           StorageClasses.GRAYSCALE_SOFTCOPY_PRESENTATION_STATE,
-          StorageClasses.PSEUDOCOLOR_SOFTCOPY_PRESENTATION_STATE,
-        ],
-      });
+          StorageClasses.PSEUDOCOLOR_SOFTCOPY_PRESENTATION_STATE
+        ]
+      })
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -248,15 +248,15 @@ class App extends React.Component<AppProps, AppState> {
   addGcpSecondaryAnnotationServer(config: AppProps['config']) {
     const serverId = 'gcp_secondary_annotation_server';
     const urlParams = new URLSearchParams(window.location.search);
-    const gcpPath = urlParams.get("gcp");
+    const url = urlParams.get("gcp");
     const gcpSecondaryAnnotationServer = config.servers.find(
       (server) => server.id === serverId
     );
-    if (!gcpSecondaryAnnotationServer && gcpPath) {
+    if (!gcpSecondaryAnnotationServer && url) {
       config.servers.push({
         id: serverId,
         write: true,
-        url: `https://healthcare.googleapis.com/v1beta1/${gcpPath}`,
+        url,
         storageClasses: [
           StorageClasses.COMPREHENSIVE_SR,
           StorageClasses.COMPREHENSIVE_3D_SR,

--- a/src/services/NotificationMiddleware.js
+++ b/src/services/NotificationMiddleware.js
@@ -49,7 +49,6 @@ const NotificationSourceDefinition = {
 }
 
 class NotificationMiddleware extends PubSub {
-
   /**
  * Error handling middleware function
  *
@@ -57,7 +56,7 @@ class NotificationMiddleware extends PubSub {
  * @param error - error object
  */
   onError (source, error) {
-    const errorCategory = error.type;
+    const errorCategory = error.type
     const sourceConfig = NotificationSourceDefinition.sources.find(
       s => s.category === errorCategory
     )
@@ -86,10 +85,9 @@ class NotificationMiddleware extends PubSub {
 
       case NotificationType.CONSOLE:
         console.error(`A ${errorCategory} error occurred: `, error)
-        return
+        break
 
       default:
-        return
     }
   }
 }

--- a/src/utils/CustomError.js
+++ b/src/utils/CustomError.js
@@ -6,12 +6,12 @@ const errorTypes = {
 }
 
 class CustomError extends Error {
-    constructor(type, message) {
-      super();
-      this.message = message;
-      this.stack = new Error().stack;
-      this.type = type
-    }
+  constructor (type, message) {
+    super()
+    this.message = message
+    this.stack = new Error().stack
+    this.type = type
+  }
 }
-  
-export {errorTypes, CustomError};
+
+export { errorTypes, CustomError }

--- a/src/utils/PubSub.js
+++ b/src/utils/PubSub.js
@@ -8,7 +8,7 @@ const _lastSubscriptionId = Symbol('lastSubscriptionId')
  * @classdesc Enables publishing/subscribing
  */
 export default class PubSub {
-  constructor() {
+  constructor () {
     this[_subscriptions] = {}
     this[_lastSubscriptionId] = 0
   }
@@ -19,7 +19,7 @@ export default class PubSub {
    * @param {Function} callback Function to be executed when event is published
    * @returns {void}
    */
-  subscribe(eventName, callback) {
+  subscribe (eventName, callback) {
     if (eventName === undefined) {
       throw new Error('Trying to subscribe to an inexistent event')
     }
@@ -42,9 +42,9 @@ export default class PubSub {
    * @param {Function} [callback] Function to have its subscription removed
    * @returns {void}
    */
-  unsubscribe(eventName, callback) {
+  unsubscribe (eventName, callback) {
     const callbacks = this[_subscriptions][eventName] || {}
-    for (let subscriptionId in callbacks) {
+    for (const subscriptionId in callbacks) {
       if (!callback) {
         delete callbacks[subscriptionId]
       } else if (callbacks[subscriptionId] === callback) {
@@ -59,13 +59,13 @@ export default class PubSub {
    * @param {any} [payload] Payload that will be passed to the callback fuction
    * @returns {void}
    */
-  publish(eventName, ...payload) {
+  publish (eventName, ...payload) {
     if (eventName === undefined) {
       throw new Error('Trying to publish an inexistent event')
     }
 
     const callbacks = this[_subscriptions][eventName] || {}
-    for (let subscriptionId in callbacks) {
+    for (const subscriptionId in callbacks) {
       callbacks[subscriptionId](...payload)
     }
   }
@@ -74,10 +74,10 @@ export default class PubSub {
    * Cleares all subscriptions for current instance
    * @returns {void}
    */
-  unsubscribeFromAll() {
-    for (let eventName in this[_subscriptions]) {
+  unsubscribeFromAll () {
+    for (const eventName in this[_subscriptions]) {
       const callbacks = this[_subscriptions][eventName]
-      for (let subscriptionId in callbacks) {
+      for (const subscriptionId in callbacks) {
         delete callbacks[subscriptionId]
       }
     }

--- a/types/dicom-microscopy-viewer/index.d.ts
+++ b/types/dicom-microscopy-viewer/index.d.ts
@@ -43,8 +43,8 @@ declare module 'dicom-microscopy-viewer' {
       render (options: object): void
       navigate (options: { level?: number, position?: number[] })
       cleanup (): void
-      get numLevels(): number
-      get frameOfReferenceUID(): string
+      get numLevels (): number
+      get frameOfReferenceUID (): string
       getPixelSpacing (level: number): number[]
       get physicalOffset (): number[]
       get physicalSize (): number[]
@@ -198,8 +198,8 @@ declare module 'dicom-microscopy-viewer' {
       showAnnotationGroup (
         annotationGroupUID: string,
         styleOptions?: {
-          opacity?: number,
-          color?: number[],
+          opacity?: number
+          color?: number[]
           measurement?: dcmjs.sr.coding.CodedConcept
         }
       ): void
@@ -207,13 +207,13 @@ declare module 'dicom-microscopy-viewer' {
       setAnnotationGroupStyle (
         annotationGroupUID: string,
         styleOptions: {
-          opacity?: number,
-          color?: number[],
+          opacity?: number
+          color?: number[]
           measurement?: dcmjs.sr.coding.CodedConcept
         }
       ): void
       getAnnotationGroupStyle (annotationGroupUID: string): {
-        opacity: number,
+        opacity: number
         color: number[]
       }
       isAnnotationGroupVisible (annotationGroupUID: string): boolean


### PR DESCRIPTION
Adding the ability to use a secondary annotations server passed in the url with the gcp query parameter.

Solves https://github.com/ImagingDataCommons/slim/issues/186

Before: 

Only one server allowed.

After:

https://github.com/ImagingDataCommons/slim/assets/22822446/9c01d40d-04b6-4b8c-a9e6-b00a0d9f85dc

