### PR TITLE
Add GCP url support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,9 @@ function ParametrizedCaseViewer ({ clients, user, app, config }: {
   )
 }
 
-function _createClientMapping ({ baseUri, settings, onError }: {
+function _createClientMapping ({ baseUri, gcpBaseUrl, settings, onError }: {
   baseUri: string
+  gcpBaseUrl: string
   settings: ServerSettings[]
   onError: (
     error: dwc.api.DICOMwebClientError,
@@ -82,6 +83,12 @@ function _createClientMapping ({ baseUri, settings, onError }: {
         }
       })
     } else {
+      if (window.location.pathname.includes('/projects/')) {
+        const pathname = window.location.pathname.split('/study/')[0]
+        const pathUrl = `${gcpBaseUrl}${pathname}/dicomWeb`;
+        serverSettings.url = pathUrl;
+      }
+
       storageClassMapping.default += 1
       clientMapping.default = new DicomWebManager({
         baseUri,
@@ -237,6 +244,7 @@ class App extends React.Component<AppProps, AppState> {
     this.state = {
       clients: _createClientMapping({
         baseUri,
+        gcpBaseUrl: props.config.gcpBaseUrl || 'https://healthcare.googleapis.com/v1',
         settings: props.config.servers,
         onError: this.handleDICOMwebError
       }),
@@ -474,6 +482,29 @@ class App extends React.Component<AppProps, AppState> {
             />
             <Route
               path='/studies/:studyInstanceUID/*'
+              element={
+                <Layout style={layoutStyle}>
+                  <Header
+                    app={appInfo}
+                    user={this.state.user}
+                    showWorklistButton={enableWorklist}
+                    onServerSelection={this.handleServerSelection}
+                    onUserLogout={isLogoutPossible ? onLogout : undefined}
+                    showServerSelectionButton={enableServerSelection}
+                  />
+                  <Layout.Content style={layoutContentStyle}>
+                    <ParametrizedCaseViewer
+                      clients={this.state.clients}
+                      user={this.state.user}
+                      config={this.props.config}
+                      app={appInfo}
+                    />
+                  </Layout.Content>
+                </Layout>
+              }
+            />
+            <Route
+              path='/projects/:project/locations/:location/datasets/:dataset/dicomStores/:dicomStore/study/:studyInstanceUID/*'
               element={
                 <Layout style={layoutStyle}>
                   <Header

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,8 +85,8 @@ function _createClientMapping ({ baseUri, gcpBaseUrl, settings, onError }: {
     } else {
       if (window.location.pathname.includes('/projects/')) {
         const pathname = window.location.pathname.split('/study/')[0]
-        const pathUrl = `${gcpBaseUrl}${pathname}/dicomWeb`;
-        serverSettings.url = pathUrl;
+        const pathUrl = `${gcpBaseUrl}${pathname}/dicomWeb`
+        serverSettings.url = pathUrl
       }
 
       storageClassMapping.default += 1
@@ -244,7 +244,7 @@ class App extends React.Component<AppProps, AppState> {
     this.state = {
       clients: _createClientMapping({
         baseUri,
-        gcpBaseUrl: props.config.gcpBaseUrl || 'https://healthcare.googleapis.com/v1',
+        gcpBaseUrl: props.config.gcpBaseUrl ?? 'https://healthcare.googleapis.com/v1',
         settings: props.config.servers,
         onError: this.handleDICOMwebError
       }),

--- a/src/AppConfig.d.ts
+++ b/src/AppConfig.d.ts
@@ -87,6 +87,7 @@ export default interface AppConfig {
   path: string
   annotations: AnnotationSettings[]
   organization?: string
+  gcpBaseUrl?: string
   oidc?: OidcSettings
   disableWorklist?: boolean
   disableAnnotationTools?: boolean

--- a/src/components/CaseViewer.tsx
+++ b/src/components/CaseViewer.tsx
@@ -195,12 +195,21 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
       `/studies/${this.props.studyInstanceUID}` +
       `/series/${seriesInstanceUID}`
     )
+
     if (this.props.location.pathname.includes('/projects/')) {
-      urlPath = this.props.location.pathname + `/series/${seriesInstanceUID}`
+      urlPath = this.props.location.pathname
+      if (!this.props.location.pathname.includes('/series/')) {
+        urlPath += `/series/${seriesInstanceUID}`
+      }
     }
-    if (this.props.location.search != null) {
+
+    if (
+      this.props.location.pathname.includes('/series/') &&
+      this.props.location.search != null
+    ) {
       urlPath += this.props.location.search
     }
+    
     this.props.navigate(urlPath, { replace: true })
   }
 
@@ -225,8 +234,8 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
      */
     let selectedSeriesInstanceUID: string
     if (this.props.location.pathname.includes('series/')) {
-      const fragments = this.props.location.pathname.split('/')
-      selectedSeriesInstanceUID = fragments[4]
+      const seriesFragment = this.props.location.pathname.split('series/')[1]
+      selectedSeriesInstanceUID = seriesFragment.includes('/') ? seriesFragment.split('/')[0] : seriesFragment
     } else {
       selectedSeriesInstanceUID = volumeInstances[0].SeriesInstanceUID
     }

--- a/src/components/CaseViewer.tsx
+++ b/src/components/CaseViewer.tsx
@@ -195,10 +195,10 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
       `/studies/${this.props.studyInstanceUID}` +
       `/series/${seriesInstanceUID}`
     )
-    if (
-      this.props.location.pathname.includes('/series/') &&
-      this.props.location.search != null
-    ) {
+    if (this.props.location.pathname.includes('/projects/')) {
+      urlPath = this.props.location.pathname + `/series/${seriesInstanceUID}`
+    }
+    if (this.props.location.search != null) {
       urlPath += this.props.location.search
     }
     this.props.navigate(urlPath, { replace: true })

--- a/src/components/CaseViewer.tsx
+++ b/src/components/CaseViewer.tsx
@@ -209,7 +209,7 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
     ) {
       urlPath += this.props.location.search
     }
-    
+
     this.props.navigate(urlPath, { replace: true })
   }
 


### PR DESCRIPTION
#208 

## Allow using the following URL formats:

### GCP path to a study
```
http://localhost:3000/projects/idc-external-031/locations/us-central1/datasets/slim-bulk-ann-images/dicomStores/slim-bulk-ann-images/study/2.25.68803095896966276583382138924964839274/series/1.3.6.1.4.1.5962.99.1.1163866303.1057408148.1637546438847.2.0
```

### GCP path to a study + GCP query param pointing to the derived data store (annotations)
```
http://localhost:3000/projects/idc-external-031/locations/us-central1/datasets/slim-bulk-ann-images/dicomStores/slim-bulk-ann-images/study/2.25.68803095896966276583382138924964839274/series/1.3.6.1.4.1.5962.99.1.1163866303.1057408148.1637546438847.2.0?gcp=https://healthcare.googleapis.com/v1/projects/idc-external-031/locations/us-central1/datasets/slim-bulk-ann-annotations/dicomStores/slim-bulk-ann-annotations/dicomWeb
```