### PR TITLE
chore: update rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-scripts/css-loader/semver": "7.5.2",
     "react-scripts/react-dev-utils/fork-ts-checker-webpack-plugin/semver": "7.5.2",
     "@semantic-release/npm/npm/**/semver": "7.5.2",
-    "express": "4.21.0"
+    "express": "4.21.0",
+    "rollup": "3.29.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11234,10 +11234,10 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.43.1:
-  version "2.79.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+rollup@3.29.5, rollup@^2.43.1:
+  version "3.29.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.5.tgz#8a2e477a758b520fb78daf04bca4c522c1da8a54"
+  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Solves this issue that was generated by the last package updates:

https://github.com/ImagingDataCommons/slim/security/dependabot/73