### PR TITLE
fix: autoload annotation styles

### DIFF
--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -69,6 +69,12 @@ const DEFAULT_ANNOTATION_COLOR_PALETTE = [
   [0, 0, 0]
 ]
 
+type StyleOptions = {
+  opacity: number
+  color: number[]
+  contourOnly: boolean
+}
+
 const _buildKey = (concept: {
   CodeValue: string
   CodeMeaning: string
@@ -473,11 +479,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
   private roiStyles: {[key: string]: dmv.viewer.ROIStyleOptions} = {}
 
   private defaultAnnotationStyles: {
-    [annotationUID: string]: {
-      opacity: number
-      color: number[]
-      contourOnly: boolean
-    }
+    [annotationUID: string]: StyleOptions
   } = {}
 
   private readonly selectionColor: number[] = [140, 184, 198]
@@ -2653,11 +2655,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
   }
 
   generateRoiStyle (
-    styleOptions: {
-      opacity?: number
-      color?: number[]
-      contourOnly: boolean
-    }): dmv.viewer.ROIStyleOptions {
+    styleOptions: StyleOptions): dmv.viewer.ROIStyleOptions {
     const opacity = styleOptions.opacity ?? DEFAULT_ANNOTATION_OPACITY
     const strokeColor = styleOptions.color ?? DEFAULT_ANNOTATION_STROKE_COLOR
     const fillColor = styleOptions.contourOnly ? [0, 0, 0, 0] : strokeColor.map((c) => Math.min(c + 25, 255))
@@ -2671,11 +2669,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
 
   handleRoiStyleChange ({ uid, styleOptions }: {
     uid: string
-    styleOptions: {
-      opacity: number
-      color: number[]
-      contourOnly: boolean
-    }
+    styleOptions: StyleOptions
   }): void {
     console.log(`change style of ROI ${uid}`)
     try {
@@ -3507,7 +3501,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
         color,
         opacity: DEFAULT_ANNOTATION_OPACITY,
         contourOnly: false
-      } as any
+      } as StyleOptions
 
       this.roiStyles[key] = this.generateRoiStyle(
         this.defaultAnnotationStyles[annotation.uid]

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -3495,26 +3495,26 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
 
     let annotationGroupMenu
 
-    if (annotations.length > 0) {
-      annotations.forEach((annotation) => {
-        const roi = this.volumeViewer.getROI(annotation.uid)
-        const key = _getRoiKey(roi) as string
-        const color = this.roiStyles[key] !== undefined
-          ? this.roiStyles[key].stroke?.color.slice(0, 3)
-          : DEFAULT_ANNOTATION_COLOR_PALETTE[
-            Object.keys(this.roiStyles).length % DEFAULT_ANNOTATION_COLOR_PALETTE.length
-          ]
-        this.defaultAnnotationStyles[annotation.uid] = {
-          color,
-          opacity: DEFAULT_ANNOTATION_OPACITY,
-          contourOnly: false
-        } as any
+    annotations?.forEach?.((annotation) => {
+      const roi = this.volumeViewer.getROI(annotation.uid)
+      const key = _getRoiKey(roi) as string
+      const color = this.roiStyles[key] !== undefined
+        ? this.roiStyles[key].stroke?.color.slice(0, 3)
+        : DEFAULT_ANNOTATION_COLOR_PALETTE[
+          Object.keys(this.roiStyles).length % DEFAULT_ANNOTATION_COLOR_PALETTE.length
+        ]
+      this.defaultAnnotationStyles[annotation.uid] = {
+        color,
+        opacity: DEFAULT_ANNOTATION_OPACITY,
+        contourOnly: false
+      } as any
 
-        this.roiStyles[key] = this.generateRoiStyle(
-          this.defaultAnnotationStyles[annotation.uid]
-        )
-      })
-    }
+      this.roiStyles[key] = this.generateRoiStyle(
+        this.defaultAnnotationStyles[annotation.uid]
+      )
+
+      this.volumeViewer.setROIStyle(roi.uid, this.roiStyles[key])
+    })
 
     if (annotationGroups.length > 0) {
       const annotationGroupMetadata: {

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -69,7 +69,7 @@ const DEFAULT_ANNOTATION_COLOR_PALETTE = [
   [0, 0, 0]
 ]
 
-type StyleOptions = {
+interface StyleOptions {
   opacity: number
   color: number[]
   contourOnly: boolean

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -3498,10 +3498,10 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           Object.keys(this.roiStyles).length % DEFAULT_ANNOTATION_COLOR_PALETTE.length
         ]
       this.defaultAnnotationStyles[annotation.uid] = {
-        color,
+        color: color as number[],
         opacity: DEFAULT_ANNOTATION_OPACITY,
         contourOnly: false
-      } as StyleOptions
+      }
 
       this.roiStyles[key] = this.generateRoiStyle(
         this.defaultAnnotationStyles[annotation.uid]


### PR DESCRIPTION
Pre-selected SRs would show with the wrong color in the first load, as explained [here](https://github.com/ImagingDataCommons/slim/issues/184#issuecomment-2644277823). 

This PR fixes this issue, making sure the annotations have the correct color even when they are pre-selected.

Before:
Wrong colors on autoload
![image](https://github.com/user-attachments/assets/9031473c-4c12-4e63-8ddc-f811bd877762)

After:
Correct colors on autoload
![image](https://github.com/user-attachments/assets/7890f562-68ac-4c4a-aa60-acef9cce6ffd)


