### PR TITLE
fix: annotation selection styles

### DIFF
--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -3507,7 +3507,9 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
         this.defaultAnnotationStyles[annotation.uid]
       )
 
-      this.volumeViewer.setROIStyle(roi.uid, this.roiStyles[key])
+      if (!this.state.selectedRoiUIDs.has(annotation.uid)) {
+        this.volumeViewer.setROIStyle(roi.uid, this.roiStyles[key])
+      }
     })
 
     if (annotationGroups.length > 0) {


### PR DESCRIPTION
Styles for selected annotations broke with last update: they would automatically go back to the default style on every render instead of remaining with the selected style.

This PR fixes it by only applying the default style when the annotation is not selected.

