### PR TITLE
fix: use dmv folder for wasm files

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_CONFIG='preview'
+REACT_APP_CONFIG='local'

--- a/craco.config.js
+++ b/craco.config.js
@@ -39,7 +39,7 @@ module.exports = {
         */
         alias: {
           'dicom-microscopy-viewer':
-            'dicom-microscopy-viewer/dist/dynamic-import/dicom-microscopy-viewer/dicomMicroscopyViewer.min.js'
+            'dicom-microscopy-viewer/dist/dynamic-import/dicomMicroscopyViewer.min.js'
         }
       }
       config.plugins.push(
@@ -47,8 +47,8 @@ module.exports = {
         new CopyWebpackPlugin({
           patterns: [
             {
-              from: './node_modules/dicom-microscopy-viewer/dist/dynamic-import/dicom-microscopy-viewer',
-              to: './dicom-microscopy-viewer'
+              from: './node_modules/dicom-microscopy-viewer/dist/dynamic-import',
+              to: './static/js'
             }
           ]
         })

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "craco-less": "^2.0.0",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "^0.48.2",
+    "dicom-microscopy-viewer": "^0.48.3",
     "dicomweb-client": "^0.10.3",
     "gh-pages": "^5.0.0",
     "oidc-client": "^1.11.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,10 +4978,10 @@ detective@^5.2.1:
     defined "^1.0.0"
     minimist "^1.2.6"
 
-dicom-microscopy-viewer@^0.48.2:
-  version "0.48.2"
-  resolved "https://registry.yarnpkg.com/dicom-microscopy-viewer/-/dicom-microscopy-viewer-0.48.2.tgz#3aa6fe14a98c1aefcf2452026587c03d714014df"
-  integrity sha512-6xKB7TL0+NiI+tsRM5Yck1H925kRvoxkU563SqUY1v7dWyjbar3mXB4/YVtMyISLSFDN/4nCx0WHTLRHWmQjeA==
+dicom-microscopy-viewer@^0.48.3:
+  version "0.48.3"
+  resolved "https://registry.yarnpkg.com/dicom-microscopy-viewer/-/dicom-microscopy-viewer-0.48.3.tgz#af99911270970205cf29a560f7ebfa4591a6d5c0"
+  integrity sha512-BXXQSZx4dNhKGHJB8Wo1Q2o6UAoqpxROmM0Z8JMoIqkhVPOaSgisUkm3XYm/STK0GiU+ZjIPX2FYHYE+k86+iw==
   dependencies:
     "@cornerstonejs/codec-charls" "^1.2.3"
     "@cornerstonejs/codec-libjpeg-turbo-8bit" "^1.2.2"
@@ -11371,9 +11371,9 @@ semver@^7.1.2, semver@^7.5.2:
     lru-cache "^6.0.0"
 
 semver@^7.3.5, semver@^7.3.7:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 send@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
- Use dmv sub directory for wasm files to avoid import conflicts
- Relative for js files
- Wait for https://github.com/ImagingDataCommons/dicom-microscopy-viewer/pull/183/files