### PR TITLE
feat: Add parametric map toggle

### DIFF
--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -252,6 +252,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       loadingFrames: new Set(),
       isICCProfilesEnabled: true,
       isSegmentationInterpolationEnabled: false,
+      isParametricMapInterpolationEnabled: true,
       customizedSegmentColors: {}
     }
   }
@@ -2851,6 +2852,16 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
     ;(this.volumeViewer as any).toggleSegmentationInterpolation()
   }
 
+  /**
+   * Handler that will toggle the parametric map interpolation, i.e., either
+   * enable or disable it, depending on its current state.
+   */
+  handleParametricMapInterpolationToggle = (event: CheckboxChangeEvent): void => {
+    const checked = event.target.checked
+    this.setState({ isParametricMapInterpolationEnabled: checked })
+    ;(this.volumeViewer as any).toggleParametricMapInterpolation()
+  }
+
   formatAnnotation = (annotation: AnnotationCategoryAndType): void => {
     const roi = this.volumeViewer.getROI(annotation.uid)
     const key = getRoiKey(roi) as string
@@ -3654,6 +3665,20 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
     )
   }
 
+  private readonly getParametricMapInterpolationMenu = (): React.ReactNode => {
+    const mappings = this.volumeViewer.getAllParameterMappings()
+    return mappings.length > 0 && (
+      <div style={{ margin: '0.9rem' }}>
+        <Checkbox
+          checked={this.state.isParametricMapInterpolationEnabled}
+          onChange={this.handleParametricMapInterpolationToggle}
+        >
+          Parametric Map Interpolation
+        </Checkbox>
+      </div>
+    )
+  }
+
   render = (): React.ReactNode => {
     const { rois, segments, mappings, annotationGroups, annotations } = this.getDataFromViewer()
 
@@ -3673,6 +3698,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
     const selectedRoiInformation = this.getSelectedRoiInformation()
     const iccProfilesMenu = this.getICCProfilesMenu()
     const segmentationInterpolationMenu = this.getSegmentationInterpolationMenu()
+    const parametricMapInterpolationMenu = this.getParametricMapInterpolationMenu()
 
     if (segmentationMenu !== null && segmentationMenu !== undefined) {
       openSubMenuItems.push('segmentations')
@@ -3728,6 +3754,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           specimenMenu={specimenMenu}
           iccProfilesMenu={iccProfilesMenu}
           segmentationInterpolationMenu={segmentationInterpolationMenu}
+          parametricMapInterpolationMenu={parametricMapInterpolationMenu}
           equipmentMenu={equipmentMenu}
           opticalPathMenu={opticalPathMenu}
           presentationStateMenu={presentationStateMenu}

--- a/src/components/SlideViewer/SlideViewerSidebar.tsx
+++ b/src/components/SlideViewer/SlideViewerSidebar.tsx
@@ -13,6 +13,7 @@ interface SlideViewerSidebarProps {
   specimenMenu: React.ReactNode
   iccProfilesMenu: React.ReactNode
   segmentationInterpolationMenu: React.ReactNode
+  parametricMapInterpolationMenu: React.ReactNode
   equipmentMenu: React.ReactNode
   opticalPathMenu: React.ReactNode
   presentationStateMenu: React.ReactNode
@@ -37,6 +38,7 @@ const SlideViewerSidebar: React.FC<SlideViewerSidebarProps> = ({
   specimenMenu,
   iccProfilesMenu,
   segmentationInterpolationMenu,
+  parametricMapInterpolationMenu,
   equipmentMenu,
   opticalPathMenu,
   presentationStateMenu,
@@ -92,6 +94,7 @@ const SlideViewerSidebar: React.FC<SlideViewerSidebarProps> = ({
         {specimenMenu}
         {iccProfilesMenu}
         {segmentationInterpolationMenu}
+        {parametricMapInterpolationMenu}
         {equipmentMenu}
         {opticalPathMenu}
         {presentationStateMenu}

--- a/src/components/SlideViewer/types.ts
+++ b/src/components/SlideViewer/types.ts
@@ -118,5 +118,6 @@ export interface SlideViewerState {
   loadingFrames: Set<string>
   isICCProfilesEnabled: boolean
   isSegmentationInterpolationEnabled: boolean
+  isParametricMapInterpolationEnabled: boolean
   customizedSegmentColors: { [segmentUID: string]: number[] }
 }

--- a/types/dicom-microscopy-viewer/index.d.ts
+++ b/types/dicom-microscopy-viewer/index.d.ts
@@ -196,7 +196,7 @@ declare module 'dicom-microscopy-viewer' {
       }
       isParameterMappingVisible (mappingUID: string): boolean
       getParameterMappingMetadata (mappingUID: string): metadata.ParametricMap[]
-      getAllParameterMappings (): dwc.mapping.ParameterMapping[]
+      getAllParameterMappings (): mapping.ParameterMapping[]
       addAnnotationGroups (
         metadata: metadata.MicroscopyBulkSimpleAnnotations
       ): void
@@ -229,6 +229,8 @@ declare module 'dicom-microscopy-viewer' {
       ): metadata.MicroscopyBulkSimpleAnnotations
       toggleICCProfiles (): void;
       getICCProfiles (): any[];
+      toggleSegmentationInterpolation (): void;
+      toggleParametricMapInterpolation (): void;
     }
 
     export interface OverviewImageViewerOptions {


### PR DESCRIPTION
# Add Parametric Map Interpolation Toggle to UI

## Summary
Adds a user interface toggle for parametric map interpolation, allowing users to enable/disable interpolation for parametric maps through a checkbox in the sidebar.

## Changes
- Added `isParametricMapInterpolationEnabled` state variable to `SlideViewerState` (defaults to `true`)
- Added `handleParametricMapInterpolationToggle` handler method
- Added `getParametricMapInterpolationMenu` method to render the interpolation checkbox
- Updated `SlideViewerSidebar` component props and rendering to include parametric map interpolation menu
- Added TypeScript definitions for `toggleParametricMapInterpolation()` in type definitions

## UI Behavior
- A checkbox labeled "Parametric Map Interpolation" appears in the sidebar when parametric maps are loaded
- The checkbox is only visible when `mappings.length > 0`
- Default state is enabled (checked)
- Follows the same pattern as the existing segmentation interpolation toggle