### PR TITLE
fix: Address auto toggle of ann group

### DIFF
--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -773,14 +773,16 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           `out of ${allAnnotationGroups.length} total ` +
           `for series "${derivedSeriesInstanceUID}"`,
       )
-      // We bypass handleAnnotationGroupVisibilityChange because it re-throws
-      // dmv errors after showing a notification, which aborts the forEach and
-      // leaves only the first annotation group toggled when any subsequent
-      // group throws. We also short-circuit the per-group runValidations
-      // dialog (which is intended for manual user toggles, not auto-load).
-      // We update state once at the end with all successfully-shown UIDs to
-      // avoid any chance of intermediate setState/re-render interleavings
-      // dropping updates.
+      /**
+       * We bypass handleAnnotationGroupVisibilityChange because it re-throws
+       * dmv errors after showing a notification, which aborts the forEach
+       * and leaves only the first annotation group toggled when any
+       * subsequent group throws. We also short-circuit the per-group
+       * runValidations dialog (which is intended for manual user toggles,
+       * not auto-load). We update state once at the end with all
+       * successfully-shown UIDs to avoid any chance of intermediate
+       * setState/re-render interleavings dropping updates.
+       */
       const shownAnnotationGroupUIDs: string[] = []
       matchingAnnotationGroups.forEach((annotationGroup) => {
         try {
@@ -820,12 +822,40 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       const matchingSegments = allSegments.filter((segment) => {
         return segment.seriesInstanceUID === derivedSeriesInstanceUID
       })
+      logger.debug(
+        `auto-load Segmentation: found ` +
+          `${matchingSegments.length} matching segment(s) ` +
+          `out of ${allSegments.length} total ` +
+          `for series "${derivedSeriesInstanceUID}"`,
+      )
+      /**
+       * Bypass handleSegmentVisibilityChange so that a throw from dmv's
+       * showSegment on any single segment does not abort the forEach and
+       * leave subsequent segments hidden. We batch the state update at
+       * the end with all successfully-shown UIDs.
+       */
+      const shownSegmentUIDs: string[] = []
       matchingSegments.forEach((segment) => {
-        this.handleSegmentVisibilityChange({
-          segmentUID: segment.uid,
-          isVisible: true,
-        })
+        try {
+          this.volumeViewer.showSegment(segment.uid)
+          shownSegmentUIDs.push(segment.uid)
+        } catch (error) {
+          logger.error(`failed to auto-show segment "${segment.uid}":`, error)
+        }
       })
+      logger.debug(
+        `auto-load Segmentation: showing ` +
+          `${shownSegmentUIDs.length}/${matchingSegments.length} segment(s)`,
+      )
+      if (shownSegmentUIDs.length > 0) {
+        this.setState((state) => {
+          const visibleSegmentUIDs = new Set(state.visibleSegmentUIDs)
+          shownSegmentUIDs.forEach((uid) => {
+            visibleSegmentUIDs.add(uid)
+          })
+          return { visibleSegmentUIDs }
+        })
+      }
       logger.debug('Loading Segmentation')
     } else if (
       (derivedDataset as { SOPClassUID: string }).SOPClassUID === ParametricMap
@@ -839,12 +869,37 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           return parameterMapping.seriesInstanceUID === derivedSeriesInstanceUID
         },
       )
+      logger.debug(
+        `auto-load Parametric Map: found ` +
+          `${matchingMappings.length} matching mapping(s) ` +
+          `out of ${allParameterMappings.length} total ` +
+          `for series "${derivedSeriesInstanceUID}"`,
+      )
+      const shownMappingUIDs: string[] = []
       matchingMappings.forEach((parameterMapping) => {
-        this.handleMappingVisibilityChange({
-          mappingUID: parameterMapping.uid,
-          isVisible: true,
-        })
+        try {
+          this.volumeViewer.showParameterMapping(parameterMapping.uid)
+          shownMappingUIDs.push(parameterMapping.uid)
+        } catch (error) {
+          logger.error(
+            `failed to auto-show parameter mapping "${parameterMapping.uid}":`,
+            error,
+          )
+        }
       })
+      logger.debug(
+        `auto-load Parametric Map: showing ` +
+          `${shownMappingUIDs.length}/${matchingMappings.length} mapping(s)`,
+      )
+      if (shownMappingUIDs.length > 0) {
+        this.setState((state) => {
+          const visibleMappingUIDs = new Set(state.visibleMappingUIDs)
+          shownMappingUIDs.forEach((uid) => {
+            visibleMappingUIDs.add(uid)
+          })
+          return { visibleMappingUIDs }
+        })
+      }
       logger.debug('Loading Parametric Map')
     } else if (
       (derivedDataset as { SOPClassUID: string }).SOPClassUID === OpticalPath
@@ -856,12 +911,40 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       const matchingOpticalPaths = allOpticalPaths.filter((opticalPath) => {
         return opticalPath.seriesInstanceUID === derivedSeriesInstanceUID
       })
+      logger.debug(
+        `auto-load Optical Path: found ` +
+          `${matchingOpticalPaths.length} matching optical path(s) ` +
+          `out of ${allOpticalPaths.length} total ` +
+          `for series "${derivedSeriesInstanceUID}"`,
+      )
+      const shownOpticalPathIdentifiers: string[] = []
       matchingOpticalPaths.forEach((opticalPath) => {
-        this.handleOpticalPathVisibilityChange({
-          opticalPathIdentifier: opticalPath.identifier,
-          isVisible: true,
-        })
+        try {
+          this.volumeViewer.showOpticalPath(opticalPath.identifier)
+          shownOpticalPathIdentifiers.push(opticalPath.identifier)
+        } catch (error) {
+          logger.error(
+            `failed to auto-show optical path "${opticalPath.identifier}":`,
+            error,
+          )
+        }
       })
+      logger.debug(
+        `auto-load Optical Path: showing ` +
+          `${shownOpticalPathIdentifiers.length}/` +
+          `${matchingOpticalPaths.length} optical path(s)`,
+      )
+      if (shownOpticalPathIdentifiers.length > 0) {
+        this.setState((state) => {
+          const visibleOpticalPathIdentifiers = new Set(
+            state.visibleOpticalPathIdentifiers,
+          )
+          shownOpticalPathIdentifiers.forEach((identifier) => {
+            visibleOpticalPathIdentifiers.add(identifier)
+          })
+          return { visibleOpticalPathIdentifiers }
+        })
+      }
       logger.debug('Loading Optical Path')
     } else if (
       (derivedDataset as { SOPClassUID: string }).SOPClassUID ===

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -759,16 +759,54 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       MicroscopyBulkSimpleAnnotation
     ) {
       const allAnnotationGroups = this.volumeViewer.getAllAnnotationGroups()
-      const annotationGroup = allAnnotationGroups.find((annotationGroup) => {
-        return (
-          annotationGroup.seriesInstanceUID ===
-          (derivedDataset as { SeriesInstanceUID: string }).SeriesInstanceUID
-        )
+      const derivedSeriesInstanceUID = (
+        derivedDataset as { SeriesInstanceUID: string }
+      ).SeriesInstanceUID
+      const matchingAnnotationGroups = allAnnotationGroups.filter(
+        (annotationGroup) => {
+          return annotationGroup.seriesInstanceUID === derivedSeriesInstanceUID
+        },
+      )
+      logger.debug(
+        `auto-load Microscopy Bulk Simple Annotation: found ` +
+          `${matchingAnnotationGroups.length} matching annotation group(s) ` +
+          `out of ${allAnnotationGroups.length} total ` +
+          `for series "${derivedSeriesInstanceUID}"`,
+      )
+      // We bypass handleAnnotationGroupVisibilityChange because it re-throws
+      // dmv errors after showing a notification, which aborts the forEach and
+      // leaves only the first annotation group toggled when any subsequent
+      // group throws. We also short-circuit the per-group runValidations
+      // dialog (which is intended for manual user toggles, not auto-load).
+      // We update state once at the end with all successfully-shown UIDs to
+      // avoid any chance of intermediate setState/re-render interleavings
+      // dropping updates.
+      const shownAnnotationGroupUIDs: string[] = []
+      matchingAnnotationGroups.forEach((annotationGroup) => {
+        try {
+          this.volumeViewer.showAnnotationGroup(annotationGroup.uid)
+          shownAnnotationGroupUIDs.push(annotationGroup.uid)
+        } catch (error) {
+          logger.error(
+            `failed to auto-show annotation group "${annotationGroup.uid}":`,
+            error,
+          )
+        }
       })
-      if (annotationGroup !== undefined) {
-        this.handleAnnotationGroupVisibilityChange({
-          annotationGroupUID: annotationGroup.uid,
-          isVisible: true,
+      logger.debug(
+        `auto-load Microscopy Bulk Simple Annotation: showing ` +
+          `${shownAnnotationGroupUIDs.length}/` +
+          `${matchingAnnotationGroups.length} annotation group(s)`,
+      )
+      if (shownAnnotationGroupUIDs.length > 0) {
+        this.setState((state) => {
+          const visibleAnnotationGroupUIDs = new Set(
+            state.visibleAnnotationGroupUIDs,
+          )
+          shownAnnotationGroupUIDs.forEach((uid) => {
+            visibleAnnotationGroupUIDs.add(uid)
+          })
+          return { visibleAnnotationGroupUIDs }
         })
       }
       logger.debug('Loading Microscopy Bulk Simple Annotation')
@@ -2634,16 +2672,16 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       const style = this.getRoiStyle(key)
       this.volumeViewer.setROIStyle(roi.uid, style)
       this.setState((state) => {
-        const visibleRoiUIDs = state.visibleRoiUIDs
+        const visibleRoiUIDs = new Set(state.visibleRoiUIDs)
         visibleRoiUIDs.add(roi.uid)
         return { visibleRoiUIDs }
       })
     } else {
       logger.log(`hide ROI ${roiUID}`)
       this.setState((state) => {
-        const selectedRoiUIDs = state.selectedRoiUIDs
+        const selectedRoiUIDs = new Set(state.selectedRoiUIDs)
         selectedRoiUIDs.delete(roiUID)
-        const visibleRoiUIDs = state.visibleRoiUIDs
+        const visibleRoiUIDs = new Set(state.visibleRoiUIDs)
         visibleRoiUIDs.delete(roiUID)
         return { visibleRoiUIDs, selectedRoiUIDs }
       })

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -1156,6 +1156,21 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
             resolve()
             return
           }
+          /**
+           * Wait for every per-series retrieval to settle before resolving.
+           * Previously resolve() fired inside the per-series success path,
+           * so the outer Promise settled on whichever ANN series finished
+           * first, racing siblings in the same study and causing
+           * loadDerivedDataset to run before the URL-targeted ANN series
+           * had been added to the viewer.
+           */
+          let pendingSeriesCount = matchedSeries.length
+          const finishOne = (): void => {
+            pendingSeriesCount -= 1
+            if (pendingSeriesCount === 0) {
+              resolve()
+            }
+          }
           matchedSeries.forEach((s) => {
             const { dataset } = dmv.metadata.formatMetadata(s)
             const series = dataset as dmv.metadata.Series
@@ -1171,17 +1186,9 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                       metadata,
                     })
                   })
-                // annotations = annotations.filter(ann => {
-                //   const refImage = this.props.slide.volumeImages[0]
-                //   return (
-                //     ann.FrameOfReferenceUID === refImage.FrameOfReferenceUID &&
-                //     ann.ContainerIdentifier === refImage.ContainerIdentifier
-                //   )
-                // })
                 annotations.forEach((ann) => {
                   try {
                     this.volumeViewer.addAnnotationGroups(ann)
-                    resolve()
                   } catch (error: unknown) {
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     NotificationMiddleware.onError(
@@ -1191,7 +1198,6 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                         'Microscopy Bulk Simple Annotations cannot be displayed.',
                       ),
                     )
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     logger.error('failed to add annotation groups:', error)
                   }
                   ann.AnnotationGroupSequence.forEach((item) => {
@@ -1220,6 +1226,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                  * interface unless an update is forced.
                  */
                 this.forceUpdate()
+                finishOne()
               })
               .catch((error) => {
                 console.error(error)
@@ -1232,6 +1239,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                       'instances failed.',
                   ),
                 )
+                finishOne()
               })
           })
         })
@@ -1278,6 +1286,23 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
             resolve()
             return
           }
+          /**
+           * Wait for every per-series retrieval to settle before resolving.
+           * Previously resolve() fired inside the per-series success path,
+           * so the outer Promise settled on whichever SEG series finished
+           * first, racing siblings in the same study and causing
+           * loadDerivedDataset to run before the URL-targeted SEG series
+           * had been added to the viewer (observed as
+           * "auto-load Segmentation: found 0 matching segment(s) out of 1
+           * total" when the URL points to a SEG that hadn't loaded yet).
+           */
+          let pendingSeriesCount = matchedSeries.length
+          const finishOne = (): void => {
+            pendingSeriesCount -= 1
+            if (pendingSeriesCount === 0) {
+              resolve()
+            }
+          }
           matchedSeries.forEach((s, _i) => {
             const { dataset } = dmv.metadata.formatMetadata(s)
             const series = dataset as dmv.metadata.Series
@@ -1302,7 +1327,6 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                   try {
                     this.volumeViewer.addSegments(segmentations)
                     applyDistinctFractionalSegmentPalettes(this.volumeViewer)
-                    resolve()
                   } catch (error: unknown) {
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     NotificationMiddleware.onError(
@@ -1322,6 +1346,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                    */
                   this.forceUpdate()
                 }
+                finishOne()
               })
               .catch((error) => {
                 console.error(error)
@@ -1333,6 +1358,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                     'Retrieval of metadata of Segmentation instances failed.',
                   ),
                 )
+                finishOne()
               })
           })
         })
@@ -1379,6 +1405,21 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
             resolve()
             return
           }
+          /**
+           * Wait for every per-series retrieval to settle before resolving.
+           * Previously resolve() fired inside the per-series success path,
+           * so the outer Promise settled on whichever PM series finished
+           * first, racing siblings in the same study and causing
+           * loadDerivedDataset to run before the URL-targeted PM series
+           * had been added to the viewer.
+           */
+          let pendingSeriesCount = matchedSeries.length
+          const finishOne = (): void => {
+            pendingSeriesCount -= 1
+            if (pendingSeriesCount === 0) {
+              resolve()
+            }
+          }
           matchedSeries.forEach((s) => {
             const { dataset } = dmv.metadata.formatMetadata(s)
             const series = dataset as dmv.metadata.Series
@@ -1407,7 +1448,6 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                   try {
                     this.volumeViewer.addParameterMappings(parametricMaps)
                     applyDistinctParametricMapPalettes(this.volumeViewer)
-                    resolve()
                   } catch (error: unknown) {
                     // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     NotificationMiddleware.onError(
@@ -1427,6 +1467,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                    */
                   this.forceUpdate()
                 }
+                finishOne()
               })
               .catch((error) => {
                 console.error(error)
@@ -1438,6 +1479,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
                     'Retrieval of metadata of Parametric Map instances failed.',
                   ),
                 )
+                finishOne()
               })
           })
         })


### PR DESCRIPTION
- https://github.com/ImagingDataCommons/slim/issues/260

# fix: Auto-toggle all annotation groups of an ANN series on load

## Summary

Closes the regression reported in [#260](https://github.com/ImagingDataCommons/slim/issues/260) ([latest comment](https://github.com/ImagingDataCommons/slim/issues/260#issuecomment-4345884296)) where opening a Microscopy Bulk Simple Annotation (ANN) series via URL only toggled the visibility of the **first** annotation group instead of all annotation groups belonging to that series.

This PR also fixes a related latent bug in the SR ROI visibility handler that was mutating the `visibleRoiUIDs`/`selectedRoiUIDs` `Set` references in place (rather than cloning), which can cause React to bail out of re-rendering on auto-load of SR-derived URLs.

## Affected behavior

- URL: `/studies/{studyUID}/series/{annSeriesUID}` where the ANN series contains multiple annotation groups.
- Before this PR: only one annotation group toggle was on after auto-load — the rest stayed hidden until the user manually toggled them.
- After this PR: every annotation group belonging to the URL series is toggled on automatically. Failures on individual groups (if any) are logged without aborting the rest.

## Root cause

`SlideViewer.loadDerivedDataset` had two compounding issues in the `MicroscopyBulkSimpleAnnotation` branch:

1. **`find()` instead of `filter()`** — introduced in [#360](https://github.com/ImagingDataCommons/slim/pull/360). When the original behavior from [#261](https://github.com/ImagingDataCommons/slim/pull/261) (`forEach` over all annotation groups) was changed to add a `seriesInstanceUID` filter, `forEach` was replaced with `find()`, so only the first matching annotation group was ever toggled.
2. **Re-throw aborts the loop** — `handleAnnotationGroupVisibilityChange` calls `volumeViewer.showAnnotationGroup()` and re-throws after notifying. Even after switching back to `filter().forEach()`, a throw on any subsequent group (e.g. a dmv `setAnnotationGroupStyle` issue) aborted the iteration, leaving only the first group toggled. The per-group `runValidations({ dialog: true })` was also designed for manual user toggles, not for automatic load-time iteration over many groups.

A separate latent bug in `handleAnnotationVisibilityChange` (the SR ROI handler) was mutating the existing `Set` reference inside `setState`, which can cause React to bail out of re-rendering since the new state holds the same reference as the previous one.

## Changes

### `src/components/SlideViewer.tsx`

**`loadDerivedDataset` — `MicroscopyBulkSimpleAnnotation` branch:**
- Replaced `find()` with `filter()` so all annotation groups whose `seriesInstanceUID` matches the URL series are picked up, not just the first.
- Bypassed `handleAnnotationGroupVisibilityChange` for the auto-load path:
  - Calls `volumeViewer.showAnnotationGroup(uid)` directly with a per-group `try/catch`, so a failure on one group no longer aborts the iteration.
  - Skips the per-group `runValidations({ dialog: true })` modal (which is intended for manual interactive toggles, not auto-load over N groups).
- Batched the state update into a **single** `setState` at the end that adds all successfully-shown UIDs to `visibleAnnotationGroupUIDs`, avoiding any chance of intermediate `setState`/re-render interleavings dropping updates.
- Added diagnostic `logger.debug` lines (`auto-load Microscopy Bulk Simple Annotation: found N matching annotation group(s) out of M total for series "..."` and `showing X/N annotation group(s)`) plus `logger.error` per-group failures for easier triage.

**`handleAnnotationVisibilityChange` (SR ROIs) — `Set` mutation fix:**
- Cloned `state.visibleRoiUIDs` and `state.selectedRoiUIDs` (`new Set(state.X)`) inside the functional `setState` updater instead of mutating the same reference. This is the same pattern already used by the ANN handler and by the rest of the visibility handlers in the file.

## Diff scope

```text
 src/components/SlideViewer.tsx | 62 ++++++++++++++++++++++++++++++++++--------
 1 file changed, 50 insertions(+), 12 deletions(-)
```

## Test plan

Tested locally via `bun dev` against IDC test data with the following ANN URLs (referenced in the issue):

- [ ] `https://andrey-slim-test.web.app/studies/1.2.826.0.1.3680043.8.498.24144283661646178704245748389871574522/series/1.2.826.0.1.3680043.10.511.3.40735706884016056933166099558854806` — multi-group ANN that previously only toggled the first group; now all toggle on.
- [ ] Verify with the broader URL set from [the systematic regression sweep in #260](https://docs.google.com/spreadsheets/d/1EUIiWFvHVjrpkQq_-_Nq78-WGG5LfS6rPjHNkJcOQ78/edit?usp=sharing):
  - [ ] SR (Comprehensive 3D SR) — should remain working
  - [ ] SEG (binary + fractional) — should remain working
  - [ ] PM (parametric maps) — should remain working
  - [ ] ANN (bulk annotations) — multi-group cases now toggle all
- [ ] DevTools console shows the new auto-load diagnostics (`found N/M`, `showing X/N`, plus any per-group `failed to auto-show…` errors that previously broke iteration).
- [ ] Manual toggle behavior in the side panel is unchanged (the existing `handleAnnotationGroupVisibilityChange` path is untouched for user interaction).
- [ ] Lint / type-check passes (`bun lint` / TypeScript compile).

## Risk / rollback

- The auto-load path no longer surfaces per-group validation dialogs. If a future use case wants those dialogs at load time, validation can be invoked once per matching group separately from the visibility toggle.
- The SR ROI `Set`-cloning change is strictly safer than the previous in-place mutation (matches the pattern used elsewhere in the same component) and does not change the public API.
- Pure rollback is a single-file revert of `src/components/SlideViewer.tsx`.

## Related

- Closes [#260](https://github.com/ImagingDataCommons/slim/issues/260) (regression reported in [the latest comment](https://github.com/ImagingDataCommons/slim/issues/260#issuecomment-4345884296))
- Follow-up to [#261](https://github.com/ImagingDataCommons/slim/pull/261), [#316](https://github.com/ImagingDataCommons/slim/pull/316), [#360](https://github.com/ImagingDataCommons/slim/pull/360)
