### PR TITLE
chore: upgrade pnpm to 11.9.0

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20.8.1
+          node-version: 24
 
       - name: Build and run containers using docker compose
         run: docker compose up -d

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -30,7 +30,16 @@ jobs:
       - name: Build
         run: REACT_APP_CONFIG=preview PUBLIC_URL=/ pnpm run build
 
-      - name: Deploy
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_SLIM }}"
+          projectId: idc-external-006
+
+      - name: Deploy to live
+        if: github.event_name == 'push'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -17,13 +17,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -20,13 +20,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,13 +16,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.34.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ RUN apt-get update && \
     unzip && \
     apt-get clean
 
-RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get update && \
     apt-get install -y --no-install-suggests --no-install-recommends \
     nodejs && \
     apt-get clean
 
-RUN corepack enable && corepack prepare pnpm@10.34.1 --activate
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 
 WORKDIR /usr/local/share/mghcomputationalpathology/slim
 
 # Install dependencies first and then include code for efficient caching
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 RUN pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.45.6",
   "private": true,
   "author": "ImagingDataCommons",
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "scripts": {
     "start": "rm -rf ./node_modules/.cache/default-development && ./scripts/set-git-env.sh craco start",
     "dev": "pnpm run start",
@@ -88,23 +88,5 @@
     "semantic-release": "21.1.2",
     "sonarqube-scanner": "^4.3.0",
     "typescript": "^4.7.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/d3-dispatch": "3.0.6",
-      "axios": "1.17.0",
-      "nth-check": "2.0.1",
-      "wrap-ansi": "7.0.0",
-      "make-dir": "3.1.0",
-      "axios>form-data": "4.0.6",
-      "express": "4.21.0",
-      "jsdom>form-data": "3.0.5",
-      "path-to-regexp": "0.1.13",
-      "rollup": "3.30.0",
-      "semver": "7.5.2",
-      "serialize-javascript": "7.0.5",
-      "tar": "7.5.16",
-      "underscore": "1.13.8"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,22 @@
+shamefullyHoist: true
+strictPeerDependencies: false
+
+allowBuilds:
+  core-js: true
+  core-js-pure: true
+
+overrides:
+  '@types/d3-dispatch': 3.0.6
+  axios: 1.17.0
+  nth-check: 2.0.1
+  wrap-ansi: 7.0.0
+  make-dir: 3.1.0
+  axios>form-data: 4.0.6
+  express: 4.21.0
+  jsdom>form-data: 3.0.5
+  path-to-regexp: 0.1.13
+  rollup: 3.30.0
+  semver: 7.5.2
+  serialize-javascript: 7.0.5
+  tar: 7.5.16
+  underscore: 1.13.8


### PR DESCRIPTION
## Summary
- Bump `packageManager` to pnpm 11.9.0
- Add `pnpm-workspace.yaml` with overrides migrated from `package.json#pnpm`
- Move `shamefullyHoist` and `strictPeerDependencies` from `.npmrc` into `pnpm-workspace.yaml` (required for pnpm 11)

## Test plan
- [ ] `corepack enable && corepack install`
- [ ] `pnpm install`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm run build`