### PR TITLE
Configure Slim logger at startup and fix icon type issues

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,10 +3,7 @@ import React from 'react'
 import type { IconType } from 'react-icons'
 
 interface ButtonProps {
-  icon:
-    | IconType
-    | React.ComponentType<Record<string, never>>
-    | React.ForwardRefExoticComponent<object>
+  icon: IconType | React.ComponentType<Record<string, unknown>>
   tooltip?: string
   label?: string
   onClick?: (options: React.SyntheticEvent) => void

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import './index.css'
 import packageInfo from '../package.json'
 import type AppConfig from './AppConfig'
 import CustomErrorBoundary from './components/CustomErrorBoundary'
+import { logger } from './utils/logger'
 
 declare global {
   interface Window {
@@ -17,6 +18,20 @@ declare global {
 const config: AppConfig = window.config
 if (config === undefined) {
   throw Error('No application configuration was provided.')
+}
+
+if (config.logger != null) {
+  logger.configure({
+    ...(config.logger.level != null
+      ? { level: logger.parseLogLevel(config.logger.level) }
+      : {}),
+    ...(config.logger.enableInProduction != null
+      ? { enableInProduction: config.logger.enableInProduction }
+      : {}),
+    ...(config.logger.enableInDevelopment != null
+      ? { enableInDevelopment: config.logger.enableInDevelopment }
+      : {}),
+  })
 }
 
 type AppProps = {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,6 @@
 /**
- * Logger utility that wraps console logging and can be configured for different environments
+ * Logger utility that wraps console logging and can be configured for different environments.
+ * Configured from `window.config.logger` at application startup.
  */
 
 export enum LogLevel {

--- a/types/react-antd-icons.d.ts
+++ b/types/react-antd-icons.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @ant-design/icons@4 types Pick pointer-capture handlers that are absent from
+ * @types/react's ts5.0 DOMAttributes. Without these, icon props are inferred as
+ * required and break JSX usage across the app.
+ */
+import 'react'
+
+declare module 'react' {
+  interface DOMAttributes<T> {
+    onPointerEnterCapture?: React.PointerEventHandler<T> | undefined
+    onPointerLeaveCapture?: React.PointerEventHandler<T> | undefined
+  }
+}


### PR DESCRIPTION
## Summary
- Configure Slim's logger from `window.config.logger` at application startup via `logger.configure()` in `index.tsx`
- Simplify `Button` icon prop typing to accept `IconType` and generic React components
- Add `types/react-antd-icons.d.ts` to augment React `DOMAttributes` with optional pointer-capture handlers required by `@ant-design/icons@4` under `@types/react` ts5.0

## Notes
- Branch is based on `master`, not `feat/viv-loader`
- Includes only the previously staged changes (logger startup config, Button typing, react-antd-icons types)
- The `types/dicom-microscopy-viewer/index.d.ts` hunk from the staged diff was omitted because `master` does not define `setLogLevel` there

## Test plan
- [ ] `pnpm run typecheck` passes
- [ ] `pnpm start` loads with `REACT_APP_CONFIG=example` and respects `config.logger` settings
- [ ] Ant Design icon buttons render without TypeScript errors