### PR TITLE
fix: declare uuid and fraction.js dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react-error-boundary": "^3.1.4",
     "react-icons": "^3.11.0",
     "react-router-dom": "^6.3.0",
-    "retry": "^0.13.1"
+    "retry": "^0.13.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.0",
@@ -81,6 +82,7 @@
     "craco-less": "^2.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-sonarjs": "^0.25.0",
+    "fraction.js": "^4.3.7",
     "gh-pages": "^5.0.0",
     "husky": "^9.1.7",
     "react-scripts": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       retry:
         specifier: ^0.13.1
         version: 0.13.1
+      uuid:
+        specifier: ^8.3.2
+        version: 8.3.2
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.15.0
@@ -151,6 +154,9 @@ importers:
       eslint-plugin-sonarjs:
         specifier: ^0.25.0
         version: 0.25.1(eslint@8.57.1)
+      fraction.js:
+        specifier: ^4.3.7
+        version: 4.3.7
       gh-pages:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3638,6 +3644,9 @@ packages:
 
   fraction.js@4.3.4:
     resolution: {integrity: sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==}
+
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -11987,6 +11996,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@4.3.4: {}
+
+  fraction.js@4.3.7: {}
 
   fraction.js@5.3.4: {}
 


### PR DESCRIPTION
## Summary
- Add `uuid` as a direct dependency (used by Header, Description, Report, and pubSubServiceInterface).
- Add `fraction.js` as a devDependency so autoprefixer/postcss-preset-env can resolve it under pnpm's layout.

Without these, `pnpm start` fails with `Can't resolve 'uuid'` and `Cannot find module 'fraction.js'`.

## Test plan
- [ ] From a clean install (`rm -rf node_modules && pnpm install`), run `REACT_APP_CONFIG=example pnpm start`
- [ ] Confirm the app compiles without uuid / fraction.js module errors
- [ ] Spot-check that CSS (index.css / App.light.less / App.dark.less) still loads