### PR TITLE
chore: clear remaining postcss and fast-uri high Dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ overrides:
   brace-expansion@2: 2.1.4
   js-yaml@3: 3.15.1
   js-yaml@4: 4.3.1
-  postcss@8: 8.5.25
+  postcss: 8.5.25
   shell-quote: 1.9.0
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   svgo: 2.8.3
   nth-check: 2.0.1
   wrap-ansi: 7.0.0
@@ -3462,8 +3462,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5401,9 +5401,6 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
-  picocolors@0.2.1:
-    resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5878,10 +5875,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@7.0.39:
-    resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
-    engines: {node: '>=6.0.0'}
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
@@ -9972,7 +9965,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11722,7 +11715,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -13770,8 +13763,6 @@ snapshots:
 
   performance-now@2.1.0: {}
 
-  picocolors@0.2.1: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -14222,11 +14213,6 @@ snapshots:
       postcss-selector-parser: 6.1.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@7.0.39:
-    dependencies:
-      picocolors: 0.2.1
-      source-map: 0.6.1
 
   postcss@8.5.25:
     dependencies:
@@ -15029,7 +15015,7 @@ snapshots:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 7.0.39
+      postcss: 8.5.25
       source-map: 0.6.1
 
   resolve.exports@1.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,12 +18,12 @@ overrides:
   # Dependabot high: js-yaml quadratic merge-key chains (v3 and v4 lines)
   js-yaml@3: 3.15.1
   js-yaml@4: 4.3.1
-  # Dependabot high: postcss sourceMappingURL path traversal (8.x only; keep 7.x for CRA)
-  postcss@8: 8.5.25
+  # Dependabot high: postcss sourceMappingURL path traversal (no 7.x patch; force 8.x)
+  postcss: 8.5.25
   # Dependabot high: shell-quote parse() quadratic DoS
   shell-quote: 1.9.0
-  # Dependabot high: fast-uri host confusion
-  fast-uri: 3.1.4
+  # Dependabot high: fast-uri host confusion (backslash authority)
+  fast-uri: 3.1.5
   # Dependabot high: SVGO removeScripts (CRA still pulls 1.x via @svgr; no SVG imports in app)
   svgo: 2.8.3
   nth-check: 2.0.1


### PR DESCRIPTION
## Summary
- Follow-up to #407: Dependabot still flagged **postcss** (#204, #207) because CRA kept `postcss@7.0.39`, which matches the advisory ranges `<=8.5.11` / `<=8.5.17` (there is no patched 7.x).
- Force **all** `postcss` consumers to **8.5.25** via pnpm override.
- Bump **fast-uri** **3.1.4 → 3.1.5** for new high alert #212 (backslash authority introducer).

## Test plan
- [x] Lockfile no longer contains `postcss@7` or `fast-uri@3.1.4`
- [ ] CI green (typecheck / build / unit tests)
- [ ] Confirm alerts #204, #207, #212 close after merge