### PR TITLE
fix: improve probabilistic SEG legend usability (#409)

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -27,8 +27,20 @@ jobs:
 
       - name: Test web page
         run: |
-          curl -sI http://localhost:8008/ | grep -o '200 OK'
-          curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
+          # Poll: compose returns as soon as the container process starts,
+          # before nginx is listening (same flake as a bare curl right after up).
+          for i in $(seq 1 30); do
+            if curl -sI http://localhost:8008/ | grep -q '200 OK' \
+              && curl -s http://localhost:8008/ | grep -q '<title>Slim</title>'; then
+              echo "Slim web page ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Slim web page did not become ready in time"
+          docker compose ps || true
+          docker compose logs --tail=80 app || true
+          exit 1
 
       - name: Test DICOMweb service
         run: |

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -36,7 +36,9 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        # Dependency build scripts are gated by allowBuilds in pnpm-workspace.yaml.
+        # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: REACT_APP_CONFIG=preview PUBLIC_URL=/ pnpm run build

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -35,7 +35,9 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        # Dependency build scripts are gated by allowBuilds in pnpm-workspace.yaml.
+        # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run predeploy

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,9 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        # Dependency build scripts are gated by allowBuilds in pnpm-workspace.yaml.
+        # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm run lint

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Raster graphics:
 - [DICOM Segmentation](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.51.html) instances that contain binary or fractional segmentation masks
 - [DICOM Parametric Map](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.75.html) instances that contain saliency maps, attention maps, class activation maps, etc.
 
+Fractional segmentations and parametric maps show an in-viewport color legend when at least one overlay is visible. The legend is collapsible and its per-item visibility toggles stay in sync with the switches in the right-hand panel.
+
 |                                                                                                                            | DICOM IOD                          |
 | :------------------------------------------------------------------------------------------------------------------------: | :--------------------------------- |
 |       <img src="docs/screenshots/IDC_CPTAC_C3N-01016-22_segmentation.png" alt="IDC CPTAC Segmentation" width="350">        | Segmentation                       |

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#03b4732f05fb7d02b6247e2d75e69c73ab5c88ff",
+    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#a7ba82aeae68f754f68142506f2e3e812b08edb1",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f",
+    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#135ad885ff71b3f38e0446a51a9e2be13d8d7674",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#135ad885ff71b3f38e0446a51a9e2be13d8d7674",
+    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f",
+    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#03b4732f05fb7d02b6247e2d75e69c73ab5c88ff",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "^0.48.22",
+    "dicom-microscopy-viewer": "github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#03b4732f05fb7d02b6247e2d75e69c73ab5c88ff
-        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff
+        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#a7ba82aeae68f754f68142506f2e3e812b08edb1
+        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/a7ba82aeae68f754f68142506f2e3e812b08edb1
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -3013,8 +3013,8 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff:
-    resolution: {gitHosted: true, integrity: sha512-zEeCQl3Zaa+MJll3mEXRVUcn2CXI21yrRl0PFpFJaYpKMwZI7q1aZ6W1ZWEDnw6c+RCYYF4mUHp5TbuqcG2fOg==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff}
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/a7ba82aeae68f754f68142506f2e3e812b08edb1:
+    resolution: {gitHosted: true, integrity: sha512-QcyyVBxKba5DSkA9T/NOR8E9Iqf3FRRztqQ9WdkzVKAdq31KwWrxQnTTaTD47fxb2JnVEhfNb8hcChptNJhayw==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/a7ba82aeae68f754f68142506f2e3e812b08edb1}
     version: 0.48.22
 
   dicomweb-client@0.10.3:
@@ -11054,7 +11054,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff:
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/a7ba82aeae68f754f68142506f2e3e812b08edb1:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: ^0.48.22
-        version: 0.48.22
+        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f
+        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -3012,8 +3012,9 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@0.48.22:
-    resolution: {integrity: sha512-IkFwh9lyAjhb6HXbSvZZu0gc462CLGN6h+6iWaZASsnaskRj3Mlrq9QOgzQJ/iYZP/aoaL87UAWn8Q2ZV+sceQ==}
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
+    resolution: {gitHosted: true, integrity: sha512-rp5mj43mvnMOTZTh6CNR3JE00PZ2lFnjYPzeKtJjuJEFsRDW/xyqDJ9bT3g/+sqFys7C0Tdf5G1WthgoeDS8Nw==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f}
+    version: 0.48.22
 
   dicomweb-client@0.10.3:
     resolution: {integrity: sha512-/fHNEAYiz8j+9TNOrNJ0k+hYqirbOT85B7vM7I4VkY8DeDQb4BDUeL3RX6huDVtn6ZQlR91dI+2tejLc5c99wA==}
@@ -11052,7 +11053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@0.48.22:
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f
-        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f
+        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#135ad885ff71b3f38e0446a51a9e2be13d8d7674
+        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -2749,6 +2749,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -3012,8 +3013,8 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
-    resolution: {gitHosted: true, integrity: sha512-rp5mj43mvnMOTZTh6CNR3JE00PZ2lFnjYPzeKtJjuJEFsRDW/xyqDJ9bT3g/+sqFys7C0Tdf5G1WthgoeDS8Nw==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f}
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674:
+    resolution: {gitHosted: true, integrity: sha512-M7sQIB3wA30BwWh4aVgkzS4gZv/+fsZqXHvm2YJ06HowzvHFK5eODKkXLU+p3dhvCWYtUyqUY93NSVifh++wAQ==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674}
     version: 0.48.22
 
   dicomweb-client@0.10.3:
@@ -11053,7 +11054,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#135ad885ff71b3f38e0446a51a9e2be13d8d7674
-        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674
+        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f
+        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -3013,8 +3013,8 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674:
-    resolution: {gitHosted: true, integrity: sha512-M7sQIB3wA30BwWh4aVgkzS4gZv/+fsZqXHvm2YJ06HowzvHFK5eODKkXLU+p3dhvCWYtUyqUY93NSVifh++wAQ==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674}
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
+    resolution: {gitHosted: true, integrity: sha512-rp5mj43mvnMOTZTh6CNR3JE00PZ2lFnjYPzeKtJjuJEFsRDW/xyqDJ9bT3g/+sqFys7C0Tdf5G1WthgoeDS8Nw==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f}
     version: 0.48.22
 
   dicomweb-client@0.10.3:
@@ -11054,7 +11054,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674:
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#1023019602f919e0cb79be9f9cf64ab283088d7f
-        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f
+        specifier: github:ImagingDataCommons/dicom-microscopy-viewer#03b4732f05fb7d02b6247e2d75e69c73ab5c88ff
+        version: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -3013,8 +3013,8 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
-    resolution: {gitHosted: true, integrity: sha512-rp5mj43mvnMOTZTh6CNR3JE00PZ2lFnjYPzeKtJjuJEFsRDW/xyqDJ9bT3g/+sqFys7C0Tdf5G1WthgoeDS8Nw==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f}
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff:
+    resolution: {gitHosted: true, integrity: sha512-zEeCQl3Zaa+MJll3mEXRVUcn2CXI21yrRl0PFpFJaYpKMwZI7q1aZ6W1ZWEDnw6c+RCYYF4mUHp5TbuqcG2fOg==, tarball: https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff}
     version: 0.48.22
 
   dicomweb-client@0.10.3:
@@ -11054,7 +11054,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f:
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ allowBuilds:
   # git-hosted packages by their exact tarball URL, so this entry must be
   # updated whenever the dependency pin in package.json changes.
   dicom-microscopy-viewer: true
-  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f': true
+  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff': true
 
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,14 @@ strictPeerDependencies: false
 allowBuilds:
   core-js: true
   core-js-pure: true
+  # Allow the git-hosted dicom-microscopy-viewer to run its prepare script,
+  # which builds dist/ when installed from a commit tarball. pnpm matches
+  # git-hosted packages by their exact tarball URL, so this entry must be
+  # updated whenever the dependency pin in package.json changes.
   dicom-microscopy-viewer: true
+  dicom-microscopy-viewer@0.48.22: true
+  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f': true
+  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/88d78adfefe3f011d26c644ac268b26feb8da6b4: set this to true or false
 
 overrides:
   '@types/d3-dispatch': 3.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,9 +9,7 @@ allowBuilds:
   # git-hosted packages by their exact tarball URL, so this entry must be
   # updated whenever the dependency pin in package.json changes.
   dicom-microscopy-viewer: true
-  dicom-microscopy-viewer@0.48.22: true
-  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f': true
-  dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/88d78adfefe3f011d26c644ac268b26feb8da6b4: set this to true or false
+  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674': true
 
 overrides:
   '@types/d3-dispatch': 3.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,7 @@ allowBuilds:
   # git-hosted packages by their exact tarball URL, so this entry must be
   # updated whenever the dependency pin in package.json changes.
   dicom-microscopy-viewer: true
-  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/03b4732f05fb7d02b6247e2d75e69c73ab5c88ff': true
-
+  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/a7ba82aeae68f754f68142506f2e3e812b08edb1': true
 
 overrides:
   '@types/d3-dispatch': 3.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,8 @@ allowBuilds:
   # git-hosted packages by their exact tarball URL, so this entry must be
   # updated whenever the dependency pin in package.json changes.
   dicom-microscopy-viewer: true
-  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/135ad885ff71b3f38e0446a51a9e2be13d8d7674': true
+  'dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/1023019602f919e0cb79be9f9cf64ab283088d7f': true
+
 
 overrides:
   '@types/d3-dispatch': 3.0.6

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -2139,9 +2139,12 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
    * Keep the side-panel segment switch in sync when the overlay's visibility
    * is toggled from the in-viewport legend (dicom-microscopy-viewer already
    * applied the change, so we only mirror it into component state).
+   *
+   * DMV's publish() wraps the argument as `detail.payload` (same shape as
+   * ROI / loading events), so read from there — not `detail` itself.
    */
   onSegmentVisibilityChanged = (event: CustomEventInit): void => {
-    const detail = event.detail as
+    const detail = event.detail?.payload as
       | { segmentUID?: string; isVisible?: boolean }
       | undefined
     if (detail?.segmentUID == null || detail.isVisible == null) {
@@ -2164,7 +2167,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
    * is toggled from the in-viewport legend.
    */
   onMappingVisibilityChanged = (event: CustomEventInit): void => {
-    const detail = event.detail as
+    const detail = event.detail?.payload as
       | { mappingUID?: string; isVisible?: boolean }
       | undefined
     if (detail?.mappingUID == null || detail.isVisible == null) {


### PR DESCRIPTION
## Summary
Fixes #409.

Companion to [dicom-microscopy-viewer#275](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/pull/275).

- Depends on `dicom-microscopy-viewer@1023019` (`fix/409-collapsible-seg-legend`) via GitHub so the in-viewport fractional SEG / parametric-map legend:
  - is hidden when no overlay is currently visible
  - can be collapsed so it does not permanently obscure the image
  - keeps legend checkboxes in sync with right-panel visibility toggles (existing slim event wiring from #388)
- Documents the behavior in the README

### Notes
- Merge / release dmv#275 first (or keep this PR pointed at the git SHA until a published release is available).

## Test plan
- [x] `pnpm install` builds dmv `dist/` via prepare
- [x] `pnpm test` — 5 suites / 39 tests passed
- [ ] Load a study with multiple fractional SEGs; confirm legend is absent until a segment is shown in the right panel
- [ ] Toggle segments from the right panel; confirm legend checkboxes match
- [ ] Toggle from the legend; confirm right-panel switches update
- [ ] Collapse the legend; confirm only the compact header remains
- [ ] Hide the last visible overlay; confirm the legend disappears