### PR TITLE
chore: bump dicom-microscopy-viewer to 0.48.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "^0.48.22",
+    "dicom-microscopy-viewer": "^0.48.23",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: ^0.48.22
-        version: 0.48.22
+        specifier: ^0.48.23
+        version: 0.48.23
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -2749,6 +2749,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -3012,8 +3013,8 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@0.48.22:
-    resolution: {integrity: sha512-IkFwh9lyAjhb6HXbSvZZu0gc462CLGN6h+6iWaZASsnaskRj3Mlrq9QOgzQJ/iYZP/aoaL87UAWn8Q2ZV+sceQ==}
+  dicom-microscopy-viewer@0.48.23:
+    resolution: {integrity: sha512-ZC3evLO0EEQyp8E6rT6VVsL5VJLqxyyPUZct2y4MBi2MTkHkR/yWEJn7wu8pTas8uC93ULWDxim5xqRa0s4/eQ==}
 
   dicomweb-client@0.10.3:
     resolution: {integrity: sha512-/fHNEAYiz8j+9TNOrNJ0k+hYqirbOT85B7vM7I4VkY8DeDQb4BDUeL3RX6huDVtn6ZQlR91dI+2tejLc5c99wA==}
@@ -11052,7 +11053,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@0.48.22:
+  dicom-microscopy-viewer@0.48.23:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,3 +38,6 @@ overrides:
   serialize-javascript: 7.0.5
   tar: 7.5.16
   underscore: 1.13.8
+
+minimumReleaseAgeExclude:
+  - dicom-microscopy-viewer@0.48.23


### PR DESCRIPTION
## Summary
- Bump `dicom-microscopy-viewer` from `^0.48.22` to `^0.48.23`
- Exclude the new version from pnpm's minimum release age policy so the lockfile resolves it immediately

## Test plan
- [x] `pnpm install` (lockfile passes supply-chain policy checks)
- [x] `tsc --noEmit` / production build (via pre-push hook)
- [x] Unit tests (via pre-push hook) — 5 suites, 39 tests passed