### PR TITLE
fix: enable scrolling on worklist content area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -517,7 +517,7 @@ class App extends React.Component<AppProps, AppState> {
     const layoutContentStyle: React.CSSProperties = {
       flex: 1,
       minHeight: 0,
-      overflow: 'hidden',
+      overflow: 'auto',
     }
 
     if (this.state.redirectTo !== undefined) {


### PR DESCRIPTION
## Summary
- Fixes worklist scrollbar issue where pagination controls were not accessible when the table content exceeded the viewport height
- Changes `Layout.Content` overflow from `hidden` to `auto` to allow vertical scrolling

## Test plan
- [ ] Load worklist with enough studies to exceed viewport height
- [ ] Verify scrollbar appears and pagination buttons are accessible at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)