### PR TITLE
fix: remove oidc from preview config

### DIFF
--- a/public/config/preview.js
+++ b/public/config/preview.js
@@ -7,12 +7,6 @@ window.config = {
       write: false
     }
   ],
-  oidc: {
-    authority: 'https://accounts.google.com',
-    clientId: '293449031882-k4um45hl4g94fsgbnviel0lh38836i9v.apps.googleusercontent.com',
-    scope: 'email profile openid https://www.googleapis.com/auth/cloud-healthcare',
-    grantType: 'implicit'
-  },
   disableWorklist: false,
   disableAnnotationTools: false,
   enableServerSelection: true,


### PR DESCRIPTION
## Summary
- Removes OIDC configuration from `public/config/preview.js`
- The preview deployment uses the public IDC proxy server which does not require authentication
- This allows PR previews to work without requiring users to sign in with Google

## Test plan
- [ ] Deploy a PR preview and verify it loads the worklist without prompting for authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)