### PR TITLE
Keep preview DICOMweb URL out of source via window.slim.env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_CONFIG='local'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Committed defaults (safe for the public repo).
+REACT_APP_CONFIG=local
+
+# Optional. Any SLIM_* variable is written to public/config/env.js as window.slim.env.SLIM_*.
+# Prefer putting private values in gitignored .env.local (overrides .env).
+# Config files may hardcode server URLs as usual, or read from window.slim.env instead.
+# Slim's own preview.js uses env so IDC DICOMweb URLs stay out of the public repo.
+# For Firebase preview/live: set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL.
+# SLIM_PREVIEW_DICOMWEB_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
-# Committed defaults (safe for the public repo).
+# Committed defaults.
 REACT_APP_CONFIG=local
 
 # Optional. Any SLIM_* variable is written to public/config/env.js as window.slim.env.SLIM_*.
-# Prefer putting private values in gitignored .env.local (overrides .env).
+# Prefer putting values you do not want in git into .env.local (overrides .env).
 # Config files may hardcode server URLs as usual, or read from window.slim.env instead.
-# Slim's own preview.js uses env so IDC DICOMweb URLs stay out of the public repo.
-# For Firebase preview/live: set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL.
+# For Firebase preview/live builds, you can set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL.
 # SLIM_PREVIEW_DICOMWEB_URL=

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,8 @@
 REACT_APP_CONFIG=local
 
 # DICOMweb URLs for public/config/*.js (exposed as window.slim.env.SLIM_*).
-# Required for the matching REACT_APP_CONFIG value.
+# SLIM_LOCAL_DICOMWEB_URL defaults to the docker-compose DICOMweb URL when unset.
 SLIM_LOCAL_DICOMWEB_URL=http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs
+# Required for demo / preview builds (also set as Actions secrets or variables):
 # SLIM_DEMO_DICOMWEB_URL=
 # SLIM_PREVIEW_DICOMWEB_URL=
-
-# Firebase / GitHub Pages CI can set SLIM_PREVIEW_DICOMWEB_URL and
-# SLIM_DEMO_DICOMWEB_URL via Actions secrets or variables.

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
-# Committed defaults.
+# Copy to .env and adjust as needed (.env is gitignored).
 REACT_APP_CONFIG=local
 
 # Optional. Any SLIM_* variable is written to public/config/env.js as window.slim.env.SLIM_*.
-# Prefer putting values you do not want in git into .env.local (overrides .env).
 # Config files may hardcode server URLs as usual, or read from window.slim.env instead.
 # For Firebase preview/live builds, you can set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL.
 # SLIM_PREVIEW_DICOMWEB_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # Copy to .env and adjust as needed (.env is gitignored).
 REACT_APP_CONFIG=local
 
-# Optional. Any SLIM_* variable is written to public/config/env.js as window.slim.env.SLIM_*.
-# Config files may hardcode server URLs as usual, or read from window.slim.env instead.
-# For Firebase preview/live builds, you can set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL.
+# DICOMweb URLs for public/config/*.js (exposed as window.slim.env.SLIM_*).
+# Required for the matching REACT_APP_CONFIG value.
+SLIM_LOCAL_DICOMWEB_URL=http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs
+# SLIM_DEMO_DICOMWEB_URL=
 # SLIM_PREVIEW_DICOMWEB_URL=
+
+# Firebase / GitHub Pages CI can set SLIM_PREVIEW_DICOMWEB_URL and
+# SLIM_DEMO_DICOMWEB_URL via Actions secrets or variables.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,11 +10,11 @@ Mark items with [x].
 <!--
 Firebase preview can install dicom-microscopy-viewer from a git branch.
 
-Option A — set an explicit branch (wins over matching names):
-  dmv-branch: feat/my-dmv-change
+Option A — set an explicit branch below (wins over matching names).
+  Example value only (do not copy the key into this comment): feat/my-dmv-change
 
 Option B — use the same branch name in Slim and dicom-microscopy-viewer
-  (for example both use feat/my-change). Leave dmv-branch empty.
+  (for example both use feat/my-change). Leave the field empty.
 
 If neither applies, the preview uses the npm pin from package.json.
 Editing this field later retriggers the Firebase preview.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ Option B — use the same branch name in Slim and dicom-microscopy-viewer
   (for example both use feat/my-change). Leave dmv-branch empty.
 
 If neither applies, the preview uses the npm pin from package.json.
+Editing this field later retriggers the Firebase preview.
 -->
 
 dmv-branch:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,82 @@
+<!--
+Thank you for contributing to Slim!
+
+Please complete the checklist before submitting.
+Mark items with [x].
+-->
+
+### DMV pairing (optional)
+
+<!--
+Firebase preview can install dicom-microscopy-viewer from a git branch.
+
+Option A — set an explicit branch (wins over matching names):
+  dmv-branch: feat/my-dmv-change
+
+Option B — use the same branch name in Slim and dicom-microscopy-viewer
+  (for example both use feat/my-change). Leave dmv-branch empty.
+
+If neither applies, the preview uses the npm pin from package.json.
+-->
+
+dmv-branch:
+
+### Context
+
+<!--
+Why this change?
+- Link the issue: Fixes #123
+- Screenshots or logs if helpful
+-->
+
+
+
+### Changes & Results
+
+<!--
+What changed, and what is the effect?
+- Before / after notes or screenshots when UI is involved
+-->
+
+
+
+### Testing
+
+<!--
+How can reviewers verify this?
+- Commands, config (REACT_APP_CONFIG=...), URLs, clicks
+-->
+
+
+
+### Checklist
+
+#### PR
+
+<!--
+Semantic-release style titles (examples):
+- feat(Worklist): add client-side pagination
+- fix(SlideViewer): correct overview sizing
+- docs(README): clarify env setup
+- chore(deps): bump dicom-microscopy-viewer
+
+The PR title is used when commits are squashed.
+-->
+
+- [ ] PR title is descriptive and follows semantic-release style
+- [ ] Linked related issues / DMV PRs when applicable
+
+#### Code
+
+- [ ] Code follows project style (`pnpm run lint`, `pnpm run fmt`)
+- [ ] Non-obvious logic is documented (JSDoc where appropriate)
+
+#### Docs
+
+- [ ] README / CONFIGURATION / CONTRIBUTING updated when behavior changes
+
+#### Tested environment
+
+- [ ] OS:
+- [ ] Node version:
+- [ ] Browser:

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           REACT_APP_CONFIG: preview
           PUBLIC_URL: /
-          # Prefer secret; fall back to variable. Keeps IDC DICOMweb URL out of source.
+          # Optional: secret preferred, variable fallback.
           SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
         run: pnpm run build
 

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -3,6 +3,8 @@ name: slim/deploy-to-firebase
 on:
   pull_request:
     branches: [master]
+    # edited: re-run when the PR body changes (e.g. add/update dmv-branch:)
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [master]
 
@@ -19,7 +21,13 @@ jobs:
   deploy-firebase:
     name: "Deploy to Firebase"
     # Forked PRs cannot access the Firebase service account secret, so skip them.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # On pull_request edited, only re-run when the body changed (dmv-branch updates).
+    if: >
+      github.event_name == 'push' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (github.event.action != 'edited' || github.event.changes.body != null)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -45,6 +53,14 @@ jobs:
           set -euo pipefail
           DMV_REPO='https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git'
 
+          is_safe_ref() {
+            # GitHub-like ref: letters, digits, and . _ / - only (no spaces/shell metacharacters).
+            case "$1" in
+              ''|*[!A-Za-z0-9._/-]*|.*|*.) return 1 ;;
+              *) return 0 ;;
+            esac
+          }
+
           # Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
           EXPLICIT="$(printf '%s\n' "${PR_BODY:-}" | sed -nE 's/^[[:space:]]*dmv-branch:[[:space:]]*//p' | head -n 1 | tr -d '[:space:]')"
           if [ -n "${EXPLICIT}" ]; then
@@ -55,14 +71,28 @@ jobs:
             SOURCE='matching-branch'
           fi
 
+          if ! is_safe_ref "${BRANCH}"; then
+            echo "::error::Unsafe DMV branch ref rejected: '${BRANCH}'"
+            exit 1
+          fi
+
           SHA="$(git ls-remote --heads "${DMV_REPO}" "refs/heads/${BRANCH}" | awk '{print $1}')"
           if [ -n "${SHA}" ]; then
+            case "${SHA}" in
+              *[!0-9a-fA-F]*|'' ) echo "::error::Unexpected git SHA from ls-remote"; exit 1 ;;
+            esac
             echo "Using DMV branch '${BRANCH}' (${SOURCE}) at ${SHA}"
             {
               echo "use_git=true"
-              echo "ref=${BRANCH}"
-              echo "sha=${SHA}"
-              echo "source=${SOURCE}"
+              echo "ref<<DMV_EOF"
+              printf '%s\n' "${BRANCH}"
+              echo "DMV_EOF"
+              echo "sha<<DMV_EOF"
+              printf '%s\n' "${SHA}"
+              echo "DMV_EOF"
+              echo "source<<DMV_EOF"
+              printf '%s\n' "${SOURCE}"
+              echo "DMV_EOF"
             } >> "${GITHUB_OUTPUT}"
           elif [ -n "${EXPLICIT}" ]; then
             echo "::error::dmv-branch '${EXPLICIT}' was set in the PR body but was not found on dicom-microscopy-viewer"
@@ -73,19 +103,29 @@ jobs:
           fi
 
       - name: Install dependencies
-        # Dependency build scripts are gated by allowBuilds in pnpm-workspace.yaml.
-        # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
+        # Install without lifecycle scripts, then rebuild only packages that need prepare
+        # (dicom-microscopy-viewer dist/). Keeps Sonar happy while still building DMV.
+        env:
+          DMV_USE_GIT: ${{ steps.dmv.outputs.use_git }}
+          DMV_REF: ${{ steps.dmv.outputs.ref }}
         run: |
           set -euo pipefail
-          if [ "${{ steps.dmv.outputs.use_git }}" = "true" ]; then
-            pnpm pkg set "dependencies.dicom-microscopy-viewer=github:ImagingDataCommons/dicom-microscopy-viewer#${{ steps.dmv.outputs.ref }}"
-            pnpm install --no-frozen-lockfile
+          if [ "${DMV_USE_GIT}" = "true" ]; then
+            case "${DMV_REF}" in
+              ''|*[!A-Za-z0-9._/-]*|.*|*.)
+                echo "::error::Unsafe DMV_REF rejected"
+                exit 1
+                ;;
+            esac
+            pnpm pkg set "dependencies.dicom-microscopy-viewer=github:ImagingDataCommons/dicom-microscopy-viewer#${DMV_REF}"
+            pnpm install --no-frozen-lockfile --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          # allowBuilds in pnpm-workspace.yaml: core-js(+pure) and dicom-microscopy-viewer
+          pnpm rebuild dicom-microscopy-viewer core-js core-js-pure
 
       - name: Require preview DICOMweb URL
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
         env:
           SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
         run: |
@@ -106,9 +146,14 @@ jobs:
         if: github.event_name == 'pull_request' && steps.dmv.outputs.use_git == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DMV_REF: ${{ steps.dmv.outputs.ref }}
+          DMV_SHA: ${{ steps.dmv.outputs.sha }}
+          DMV_SOURCE: ${{ steps.dmv.outputs.source }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --body "Firebase preview is building against [\`dicom-microscopy-viewer\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [\`${{ steps.dmv.outputs.ref }}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/${{ steps.dmv.outputs.ref }}) (\`${{ steps.dmv.outputs.sha }}\`, via \`${{ steps.dmv.outputs.source }}\`)."
+          BODY="$(printf 'Firebase preview is building against [`dicom-microscopy-viewer`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [`%s`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/%s) (`%s`, via `%s`). Editing the PR body (for example `dmv-branch:`) retriggers this preview.' \
+            "${DMV_REF}" "${DMV_REF}" "${DMV_SHA}" "${DMV_SOURCE}")"
+          gh pr comment "${PR_NUMBER}" --body "${BODY}"
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -84,11 +84,20 @@ jobs:
             pnpm install --frozen-lockfile
           fi
 
+      - name: Require preview DICOMweb URL
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        env:
+          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
+        run: |
+          if [ -z "${SLIM_PREVIEW_DICOMWEB_URL}" ]; then
+            echo "::error::Set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL (used by public/config/preview.js via window.slim.env)."
+            exit 1
+          fi
+
       - name: Build
         env:
           REACT_APP_CONFIG: preview
           PUBLIC_URL: /
-          # Optional: secret preferred, variable fallback.
           SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
           REACT_APP_DMV_GIT_SHA: ${{ steps.dmv.outputs.sha }}
         run: pnpm run build

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -41,7 +41,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: REACT_APP_CONFIG=preview PUBLIC_URL=/ pnpm run build
+        env:
+          REACT_APP_CONFIG: preview
+          PUBLIC_URL: /
+          # Prefer secret; fall back to variable. Keeps IDC DICOMweb URL out of source.
+          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
+        run: pnpm run build
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -21,7 +21,7 @@ jobs:
     # Forked PRs cannot access the Firebase service account secret, so skip them.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,10 +35,37 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - name: Resolve matching DMV branch
+        id: dmv
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BRANCH='${{ github.head_ref }}'
+          DMV_REPO='https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git'
+          SHA="$(git ls-remote --heads "$DMV_REPO" "refs/heads/${BRANCH}" | awk '{print $1}')"
+          if [ -n "${SHA}" ]; then
+            echo "Found matching DMV branch '${BRANCH}' at ${SHA}"
+            {
+              echo "use_git=true"
+              echo "ref=${BRANCH}"
+              echo "sha=${SHA}"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            echo "No matching DMV branch '${BRANCH}'; using package.json pin"
+            echo "use_git=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Install dependencies
         # Dependency build scripts are gated by allowBuilds in pnpm-workspace.yaml.
         # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
-        run: pnpm install --frozen-lockfile
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.dmv.outputs.use_git }}" = "true" ]; then
+            pnpm pkg set "dependencies.dicom-microscopy-viewer=github:ImagingDataCommons/dicom-microscopy-viewer#${{ steps.dmv.outputs.ref }}"
+            pnpm install --no-frozen-lockfile
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: Build
         env:
@@ -46,7 +73,16 @@ jobs:
           PUBLIC_URL: /
           # Optional: secret preferred, variable fallback.
           SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
+          REACT_APP_DMV_GIT_SHA: ${{ steps.dmv.outputs.sha }}
         run: pnpm run build
+
+      - name: Note DMV source on PR
+        if: github.event_name == 'pull_request' && steps.dmv.outputs.use_git == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "Firebase preview is building against [\`dicom-microscopy-viewer\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [\`${{ steps.dmv.outputs.ref }}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/${{ steps.dmv.outputs.ref }}) (\`${{ steps.dmv.outputs.sha }}\`)."
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -63,11 +63,7 @@ jobs:
 
           # Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
           # Strip HTML comments so PR-template examples cannot be parsed as values.
-          BODY_NO_COMMENTS="$(python3 - <<'PY'
-import os, re
-print(re.sub(r"<!--.*?-->", "", os.environ.get("PR_BODY", ""), flags=re.S))
-PY
-)"
+          BODY_NO_COMMENTS="$(python3 -c 'import os,re; print(re.sub(r"<!--.*?-->", "", os.environ.get("PR_BODY", ""), flags=re.S))')"
           # Prefer the last non-empty field (user-filled value wins over blanks).
           EXPLICIT=""
           while IFS= read -r line || [ -n "${line}" ]; do

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -62,7 +62,27 @@ jobs:
           }
 
           # Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
-          EXPLICIT="$(printf '%s\n' "${PR_BODY:-}" | sed -nE 's/^[[:space:]]*dmv-branch:[[:space:]]*//p' | head -n 1 | tr -d '[:space:]')"
+          # Strip HTML comments so PR-template examples cannot be parsed as values.
+          BODY_NO_COMMENTS="$(python3 - <<'PY'
+import os, re
+print(re.sub(r"<!--.*?-->", "", os.environ.get("PR_BODY", ""), flags=re.S))
+PY
+)"
+          # Prefer the last non-empty field (user-filled value wins over blanks).
+          EXPLICIT=""
+          while IFS= read -r line || [ -n "${line}" ]; do
+            case "${line}" in
+              dmv-branch:*)
+                val="${line#dmv-branch:}"
+                val="$(printf '%s' "${val}" | tr -d '[:space:]')"
+                if [ -n "${val}" ]; then
+                  EXPLICIT="${val}"
+                fi
+                ;;
+            esac
+          done <<EOF
+$(printf '%s\n' "${BODY_NO_COMMENTS}" | sed -nE 's/^[[:space:]]*(dmv-branch:.*)$/\1/p')
+EOF
           if [ -n "${EXPLICIT}" ]; then
             BRANCH="${EXPLICIT}"
             SOURCE='dmv-branch'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -35,21 +35,38 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - name: Resolve matching DMV branch
+      - name: Resolve DMV branch for preview
         id: dmv
         if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-          BRANCH='${{ github.head_ref }}'
           DMV_REPO='https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git'
-          SHA="$(git ls-remote --heads "$DMV_REPO" "refs/heads/${BRANCH}" | awk '{print $1}')"
+
+          # Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
+          EXPLICIT="$(printf '%s\n' "${PR_BODY:-}" | sed -nE 's/^[[:space:]]*dmv-branch:[[:space:]]*//p' | head -n 1 | tr -d '[:space:]')"
+          if [ -n "${EXPLICIT}" ]; then
+            BRANCH="${EXPLICIT}"
+            SOURCE='dmv-branch'
+          else
+            BRANCH="${HEAD_REF}"
+            SOURCE='matching-branch'
+          fi
+
+          SHA="$(git ls-remote --heads "${DMV_REPO}" "refs/heads/${BRANCH}" | awk '{print $1}')"
           if [ -n "${SHA}" ]; then
-            echo "Found matching DMV branch '${BRANCH}' at ${SHA}"
+            echo "Using DMV branch '${BRANCH}' (${SOURCE}) at ${SHA}"
             {
               echo "use_git=true"
               echo "ref=${BRANCH}"
               echo "sha=${SHA}"
+              echo "source=${SOURCE}"
             } >> "${GITHUB_OUTPUT}"
+          elif [ -n "${EXPLICIT}" ]; then
+            echo "::error::dmv-branch '${EXPLICIT}' was set in the PR body but was not found on dicom-microscopy-viewer"
+            exit 1
           else
             echo "No matching DMV branch '${BRANCH}'; using package.json pin"
             echo "use_git=false" >> "${GITHUB_OUTPUT}"
@@ -82,7 +99,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment "${{ github.event.pull_request.number }}" \
-            --body "Firebase preview is building against [\`dicom-microscopy-viewer\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [\`${{ steps.dmv.outputs.ref }}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/${{ steps.dmv.outputs.ref }}) (\`${{ steps.dmv.outputs.sha }}\`)."
+            --body "Firebase preview is building against [\`dicom-microscopy-viewer\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [\`${{ steps.dmv.outputs.ref }}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/${{ steps.dmv.outputs.ref }}) (\`${{ steps.dmv.outputs.sha }}\`, via \`${{ steps.dmv.outputs.source }}\`)."
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -49,74 +49,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           HEAD_REF: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-          DMV_REPO='https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git'
-
-          is_safe_ref() {
-            # GitHub-like ref: letters, digits, and . _ / - only (no spaces/shell metacharacters).
-            case "$1" in
-              ''|*[!A-Za-z0-9._/-]*|.*|*.) return 1 ;;
-              *) return 0 ;;
-            esac
-          }
-
-          # Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
-          # Strip HTML comments so PR-template examples cannot be parsed as values.
-          BODY_NO_COMMENTS="$(python3 -c 'import os,re; print(re.sub(r"<!--.*?-->", "", os.environ.get("PR_BODY", ""), flags=re.S))')"
-          # Prefer the last non-empty field (user-filled value wins over blanks).
-          EXPLICIT=""
-          while IFS= read -r line || [ -n "${line}" ]; do
-            case "${line}" in
-              dmv-branch:*)
-                val="${line#dmv-branch:}"
-                val="$(printf '%s' "${val}" | tr -d '[:space:]')"
-                if [ -n "${val}" ]; then
-                  EXPLICIT="${val}"
-                fi
-                ;;
-            esac
-          done <<EOF
-$(printf '%s\n' "${BODY_NO_COMMENTS}" | sed -nE 's/^[[:space:]]*(dmv-branch:.*)$/\1/p')
-EOF
-          if [ -n "${EXPLICIT}" ]; then
-            BRANCH="${EXPLICIT}"
-            SOURCE='dmv-branch'
-          else
-            BRANCH="${HEAD_REF}"
-            SOURCE='matching-branch'
-          fi
-
-          if ! is_safe_ref "${BRANCH}"; then
-            echo "::error::Unsafe DMV branch ref rejected: '${BRANCH}'"
-            exit 1
-          fi
-
-          SHA="$(git ls-remote --heads "${DMV_REPO}" "refs/heads/${BRANCH}" | awk '{print $1}')"
-          if [ -n "${SHA}" ]; then
-            case "${SHA}" in
-              *[!0-9a-fA-F]*|'' ) echo "::error::Unexpected git SHA from ls-remote"; exit 1 ;;
-            esac
-            echo "Using DMV branch '${BRANCH}' (${SOURCE}) at ${SHA}"
-            {
-              echo "use_git=true"
-              echo "ref<<DMV_EOF"
-              printf '%s\n' "${BRANCH}"
-              echo "DMV_EOF"
-              echo "sha<<DMV_EOF"
-              printf '%s\n' "${SHA}"
-              echo "DMV_EOF"
-              echo "source<<DMV_EOF"
-              printf '%s\n' "${SOURCE}"
-              echo "DMV_EOF"
-            } >> "${GITHUB_OUTPUT}"
-          elif [ -n "${EXPLICIT}" ]; then
-            echo "::error::dmv-branch '${EXPLICIT}' was set in the PR body but was not found on dicom-microscopy-viewer"
-            exit 1
-          else
-            echo "No matching DMV branch '${BRANCH}'; using package.json pin"
-            echo "use_git=false" >> "${GITHUB_OUTPUT}"
-          fi
+        run: ./scripts/resolve-dmv-preview-branch.sh
 
       - name: Install dependencies
         # Install without lifecycle scripts, then rebuild only packages that need prepare
@@ -167,9 +100,7 @@ EOF
           DMV_SHA: ${{ steps.dmv.outputs.sha }}
           DMV_SOURCE: ${{ steps.dmv.outputs.source }}
         run: |
-          BODY="$(printf 'Firebase preview is building against [`dicom-microscopy-viewer`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) branch [`%s`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/%s) (`%s`, via `%s`). Editing the PR body (for example `dmv-branch:`) retriggers this preview.' \
-            "${DMV_REF}" "${DMV_REF}" "${DMV_SHA}" "${DMV_SOURCE}")"
-          gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          gh pr comment "${PR_NUMBER}" --body "Firebase preview uses dicom-microscopy-viewer branch ${DMV_REF} (${DMV_SHA}, via ${DMV_SOURCE})."
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -40,6 +40,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        env:
+          # Optional: secret preferred, variable fallback.
+          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL || vars.SLIM_DEMO_DICOMWEB_URL }}
         run: pnpm run predeploy
 
       # Only pushes to master (and manual runs) publish; pull requests stop

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -39,9 +39,17 @@ jobs:
         # The git-hosted dicom-microscopy-viewer needs its prepare script to build dist/.
         run: pnpm install --frozen-lockfile
 
+      - name: Require demo DICOMweb URL
+        env:
+          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL || vars.SLIM_DEMO_DICOMWEB_URL }}
+        run: |
+          if [ -z "${SLIM_DEMO_DICOMWEB_URL}" ]; then
+            echo "::error::Set Actions secret or variable SLIM_DEMO_DICOMWEB_URL (used by public/config/demo.js via window.slim.env)."
+            exit 1
+          fi
+
       - name: Build
         env:
-          # Optional: secret preferred, variable fallback.
           SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL || vars.SLIM_DEMO_DICOMWEB_URL }}
         run: pnpm run predeploy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,26 @@ const checkValues = ({ foo, bar }: { foo: string, bar: number }): boolean => {}
 ```
 
 The types of parameters and return values are omitted in docstring comments, given that type annotations are already available in TypeScript.
+
+## Pull requests
+
+Use the repository pull request template. Include a clear summary, testing notes, and a semantic-release style title (for example `feat(Worklist): …`, `fix(SlideViewer): …`).
+
+### Pairing a Firebase preview with dicom-microscopy-viewer
+
+If your Slim change depends on an unreleased
+[dicom-microscopy-viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer)
+branch, the Firebase preview workflow can install that branch automatically:
+
+1. **Explicit:** add a line near the top of the PR body (template field):
+
+   ```text
+   dmv-branch: feat/my-dmv-change
+   ```
+
+2. **Same name:** use the same branch name in both repos (for example both
+   `feat/my-change`) and leave `dmv-branch` empty.
+
+`dmv-branch` wins when set. If it points at a branch that does not exist on DMV,
+the preview job fails. If neither option applies, the preview uses the npm pin
+from `package.json`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,6 @@ branch, the Firebase preview workflow can install that branch automatically:
 `dmv-branch` wins when set. If it points at a branch that does not exist on DMV,
 the preview job fails. If neither option applies, the preview uses the npm pin
 from `package.json`.
+
+Editing the PR description to add or change `dmv-branch:` retriggers the Firebase
+preview workflow (body edits only; title-only edits are ignored).

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ RUN chmod +x scripts/*.sh
 FROM lib AS app
 
 ARG REACT_APP_CONFIG=local
-ENV PUBLIC_URL=/
+# Public default for docker-compose DICOMweb; override at build time if needed.
+ARG SLIM_LOCAL_DICOMWEB_URL=http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs
+ENV PUBLIC_URL=/ \
+    REACT_APP_CONFIG=${REACT_APP_CONFIG} \
+    SLIM_LOCAL_DICOMWEB_URL=${SLIM_LOCAL_DICOMWEB_URL}
 
 RUN addgroup --system --gid 101 nginx && \
     adduser --system \

--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ The configuration can be specified using the `REACT_APP_CONFIG` environment vari
 REACT_APP_CONFIG=local pnpm run start
 ```
 
+Copy [`.env.example`](.env.example) for documented defaults. The repo ships a tracked `.env` with `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally, put `SLIM_*` values in gitignored `.env.local` and read them as `window.slim.env.SLIM_*` (see `scripts/inject-slim-env.mjs`). Slim’s own `preview.js` uses `SLIM_PREVIEW_DICOMWEB_URL` so IDC endpoints stay out of the public repo; set that as a GitHub Actions secret or variable for Firebase deploys.
+
 Useful scripts:
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The command line interface of the [dicomweb-client Python package](https://dicom
 dicomweb_client -vv --url http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs store instances -h
 ```
 
-The local deployment uses the default configuration file `public/config/local.js`:
+The local deployment uses the default configuration file `public/config/local.js`, which reads the DICOMweb URL from `window.slim.env.SLIM_LOCAL_DICOMWEB_URL` (set in `.env`; see `.env.example`):
 
 ```js
 window.config = {
@@ -314,7 +314,7 @@ window.config = {
   servers: [
     {
       id: "local",
-      url: "http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs",
+      url: window.slim.env.SLIM_LOCAL_DICOMWEB_URL,
       write: true,
     },
   ],
@@ -434,7 +434,7 @@ The configuration can be specified using the `REACT_APP_CONFIG` environment vari
 REACT_APP_CONFIG=local pnpm run start
 ```
 
-Copy [`.env.example`](.env.example) to `.env` (gitignored) and adjust as needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally set `SLIM_*` in `.env` and read them as `window.slim.env.SLIM_*` if you want to keep URLs out of the codebase (see `scripts/inject-slim-env.mjs`). Firebase preview builds can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or variable.
+Copy [`.env.example`](.env.example) to `.env` (gitignored) and adjust as needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Committed configs under `public/config/` read DICOMweb URLs from `window.slim.env` (`SLIM_LOCAL_DICOMWEB_URL`, `SLIM_DEMO_DICOMWEB_URL`, `SLIM_PREVIEW_DICOMWEB_URL`). Set those in `.env` or CI (see `scripts/inject-slim-env.mjs`).
 
 Useful scripts:
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ Useful scripts:
 
 If you are developing features or fixing bugs that require changes in both Slim and the underlying [`dicom-microscopy-viewer`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) library, you can use `pnpm link` to connect your local Slim project to a local clone of `dicom-microscopy-viewer`. This allows Slim to immediately use the latest local changes from the library without publishing to npm.
 
+### Firebase preview with a matching DMV branch
+
+When a Slim pull request is opened, the Firebase preview workflow looks for a branch with the **same name** on `ImagingDataCommons/dicom-microscopy-viewer`. If that branch exists, the preview installs DMV from that git ref instead of the npm pin. Otherwise it uses the version in `package.json`.
+
+Use the same branch name in both repos (for example `feat/my-change`) when Slim and DMV changes need to be tested together.
+
 ### Steps
 
 1. **Clone dicom-microscopy-viewer**  

--- a/README.md
+++ b/README.md
@@ -451,11 +451,16 @@ Useful scripts:
 
 If you are developing features or fixing bugs that require changes in both Slim and the underlying [`dicom-microscopy-viewer`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer) library, you can use `pnpm link` to connect your local Slim project to a local clone of `dicom-microscopy-viewer`. This allows Slim to immediately use the latest local changes from the library without publishing to npm.
 
-### Firebase preview with a matching DMV branch
+### Firebase preview with a paired DMV branch
 
-When a Slim pull request is opened, the Firebase preview workflow looks for a branch with the **same name** on `ImagingDataCommons/dicom-microscopy-viewer`. If that branch exists, the preview installs DMV from that git ref instead of the npm pin. Otherwise it uses the version in `package.json`.
+When a Slim pull request is opened, the Firebase preview can install
+[`dicom-microscopy-viewer`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer)
+from a git branch instead of the npm pin:
 
-Use the same branch name in both repos (for example `feat/my-change`) when Slim and DMV changes need to be tested together.
+1. Set `dmv-branch: <branch-name>` in the PR description (see the PR template), or
+2. Use the **same branch name** in both repos and leave `dmv-branch` empty.
+
+If neither applies, the preview uses the version in `package.json`. Details are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Steps
 
@@ -522,7 +527,7 @@ Use the same branch name in both repos (for example `feat/my-change`) when Slim 
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on coding style, documentation, and the development workflow.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on coding style, documentation, pull requests (including optional DMV preview pairing), and the development workflow.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The configuration can be specified using the `REACT_APP_CONFIG` environment vari
 REACT_APP_CONFIG=local pnpm run start
 ```
 
-Copy [`.env.example`](.env.example) for documented defaults. The repo ships a tracked `.env` with `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally, put `SLIM_*` values in gitignored `.env.local` and read them as `window.slim.env.SLIM_*` if you want to keep URLs out of the codebase (see `scripts/inject-slim-env.mjs`). Firebase preview builds can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or variable.
+Copy [`.env.example`](.env.example) to `.env` (gitignored) and adjust as needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally set `SLIM_*` in `.env` and read them as `window.slim.env.SLIM_*` if you want to keep URLs out of the codebase (see `scripts/inject-slim-env.mjs`). Firebase preview builds can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or variable.
 
 Useful scripts:
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,16 @@ The configuration can be specified using the `REACT_APP_CONFIG` environment vari
 REACT_APP_CONFIG=local pnpm run start
 ```
 
-Copy [`.env.example`](.env.example) to `.env` (gitignored) and adjust as needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Committed configs under `public/config/` read DICOMweb URLs from `window.slim.env` (`SLIM_LOCAL_DICOMWEB_URL`, `SLIM_DEMO_DICOMWEB_URL`, `SLIM_PREVIEW_DICOMWEB_URL`). Set those in `.env` or CI (see `scripts/inject-slim-env.mjs`).
+Copy [`.env.example`](.env.example) to `.env` (gitignored) and adjust as needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local` and `SLIM_LOCAL_DICOMWEB_URL` defaults to the docker-compose DICOMweb URL. Committed `demo` / `preview` configs require `SLIM_DEMO_DICOMWEB_URL` / `SLIM_PREVIEW_DICOMWEB_URL` in `.env` or CI (see `scripts/inject-slim-env.mjs`).
+
+### Upgrading from older Slim versions
+
+If you merge this change into a fork or redeploy:
+
+1. Copy `.env.example` to `.env` (or keep your existing `.env`).
+2. Stock `local` builds work without extra setup (localhost DICOMweb default).
+3. Before Firebase / GitHub Pages deploys, set Actions secret or variable `SLIM_PREVIEW_DICOMWEB_URL` and `SLIM_DEMO_DICOMWEB_URL`.
+4. Custom configs with hardcoded `servers[].url` keep working; only Slim’s committed `local` / `demo` / `preview` configs read `window.slim.env`.
 
 Useful scripts:
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The configuration can be specified using the `REACT_APP_CONFIG` environment vari
 REACT_APP_CONFIG=local pnpm run start
 ```
 
-Copy [`.env.example`](.env.example) for documented defaults. The repo ships a tracked `.env` with `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally, put `SLIM_*` values in gitignored `.env.local` and read them as `window.slim.env.SLIM_*` (see `scripts/inject-slim-env.mjs`). Slim’s own `preview.js` uses `SLIM_PREVIEW_DICOMWEB_URL` so IDC endpoints stay out of the public repo; set that as a GitHub Actions secret or variable for Firebase deploys.
+Copy [`.env.example`](.env.example) for documented defaults. The repo ships a tracked `.env` with `REACT_APP_CONFIG=local`. Config files may hardcode DICOMweb URLs. Optionally, put `SLIM_*` values in gitignored `.env.local` and read them as `window.slim.env.SLIM_*` if you want to keep URLs out of the codebase (see `scripts/inject-slim-env.mjs`). Firebase preview builds can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or variable.
 
 Useful scripts:
 

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ from a git branch instead of the npm pin:
 1. Set `dmv-branch: <branch-name>` in the PR description (see the PR template), or
 2. Use the **same branch name** in both repos and leave `dmv-branch` empty.
 
-If neither applies, the preview uses the version in `package.json`. Details are in [CONTRIBUTING.md](CONTRIBUTING.md).
+If neither applies, the preview uses the version in `package.json`. Editing the PR body to change `dmv-branch:` regenerates the preview. Details are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Steps
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,13 +8,11 @@ start time with the `REACT_APP_CONFIG` environment variable (defaults to
 `local`).
 
 Copy [`.env.example`](../.env.example) to `.env` (gitignored) and adjust as
-needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`.
-Committed configs under `public/config/` read DICOMweb URLs from
-`window.slim.env` (for example
-`url: window.slim.env.SLIM_LOCAL_DICOMWEB_URL`). Set `SLIM_LOCAL_DICOMWEB_URL`,
-`SLIM_DEMO_DICOMWEB_URL`, and/or `SLIM_PREVIEW_DICOMWEB_URL` in `.env` or CI
-(see `scripts/inject-slim-env.mjs`). Firebase and GitHub Pages deploys can pass
-those via Actions secrets or variables.
+needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local` and
+`SLIM_LOCAL_DICOMWEB_URL` defaults to the docker-compose DICOMweb URL.
+Committed `demo` / `preview` configs require `SLIM_DEMO_DICOMWEB_URL` /
+`SLIM_PREVIEW_DICOMWEB_URL` in `.env` or as GitHub Actions secrets/variables
+(see `scripts/inject-slim-env.mjs`).
 
 For the full type definitions, see [`src/AppConfig.d.ts`](../src/AppConfig.d.ts).
 Example configs live in [`public/config/`](../public/config/).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,14 +8,13 @@ start time with the `REACT_APP_CONFIG` environment variable (defaults to
 `local`).
 
 Copy [`.env.example`](../.env.example) to `.env` (gitignored) and adjust as
-needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Using
-`SLIM_*` env vars is optional: config files under `public/config/` may hardcode
-server URLs as usual. If you want to keep URLs out of the codebase, set `SLIM_*`
-in `.env`. Start/build writes them to `public/config/env.js` as
-`window.slim.env` (see `scripts/inject-slim-env.mjs`), and any config can read
-them (for example `url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL`). Firebase
-deploys can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or
-variable ([deploy-to-firebase](../.github/workflows/deploy-to-firebase.yml)).
+needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`.
+Committed configs under `public/config/` read DICOMweb URLs from
+`window.slim.env` (for example
+`url: window.slim.env.SLIM_LOCAL_DICOMWEB_URL`). Set `SLIM_LOCAL_DICOMWEB_URL`,
+`SLIM_DEMO_DICOMWEB_URL`, and/or `SLIM_PREVIEW_DICOMWEB_URL` in `.env` or CI
+(see `scripts/inject-slim-env.mjs`). Firebase and GitHub Pages deploys can pass
+those via Actions secrets or variables.
 
 For the full type definitions, see [`src/AppConfig.d.ts`](../src/AppConfig.d.ts).
 Example configs live in [`public/config/`](../public/config/).
@@ -33,7 +32,8 @@ Example configs live in [`public/config/`](../public/config/).
 ## External DICOMweb server
 
 Point Slim at any DICOMweb-conformant archive by setting `servers` in the config
-file:
+file. Slim’s committed configs read the URL from `window.slim.env` (set via
+`.env`); custom configs may still hardcode a URL:
 
 ```js
 window.config = {
@@ -41,7 +41,8 @@ window.config = {
   servers: [
     {
       id: 'local',
-      url: 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
+      url: window.slim.env.SLIM_LOCAL_DICOMWEB_URL,
+      // or: url: 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
       write: true,
     },
   ],
@@ -313,7 +314,8 @@ DICOMweb at:
 http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs
 ```
 
-That URL is already set in [`public/config/local.js`](../public/config/local.js).
+That URL belongs in `.env` as `SLIM_LOCAL_DICOMWEB_URL` (see `.env.example`).
+`public/config/local.js` reads it from `window.slim.env`.
 nginx in the compose stack proxies the dcm4chee DICOMweb paths; Orthanc is not
 part of that stack.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,13 +5,13 @@ The app is configured via a JavaScript file under `public/config/` (for example
 `public/config/local.js`). The file is loaded at runtime from
 `public/config/{name}.js` via `public/index.html`. Select `{name}` at build /
 start time with the `REACT_APP_CONFIG` environment variable (defaults to
-`local` via `.env`).
+`local`).
 
-Copy [`.env.example`](../.env.example) for documented defaults. The repo ships a
-tracked `.env` with `REACT_APP_CONFIG=local`. Using `SLIM_*` env vars is
-optional: config files under `public/config/` may hardcode server URLs as usual.
-If you want to keep URLs out of the codebase, put `SLIM_*` values in gitignored
-`.env.local`. Start/build writes them to `public/config/env.js` as
+Copy [`.env.example`](../.env.example) to `.env` (gitignored) and adjust as
+needed. Without `.env`, start/build defaults to `REACT_APP_CONFIG=local`. Using
+`SLIM_*` env vars is optional: config files under `public/config/` may hardcode
+server URLs as usual. If you want to keep URLs out of the codebase, set `SLIM_*`
+in `.env`. Start/build writes them to `public/config/env.js` as
 `window.slim.env` (see `scripts/inject-slim-env.mjs`), and any config can read
 them (for example `url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL`). Firebase
 deploys can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -7,6 +7,17 @@ The app is configured via a JavaScript file under `public/config/` (for example
 start time with the `REACT_APP_CONFIG` environment variable (defaults to
 `local` via `.env`).
 
+Copy [`.env.example`](../.env.example) for documented defaults. The repo ships a
+tracked `.env` with `REACT_APP_CONFIG=local`. Using `SLIM_*` env vars is
+optional: config files under `public/config/` may hardcode server URLs as usual.
+Put private `SLIM_*` values in gitignored `.env.local`. Start/build writes them
+to `public/config/env.js` as `window.slim.env` (see
+`scripts/inject-slim-env.mjs`), and any config can read them (for example
+`url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL`). Slim’s own `preview.js` uses
+env so IDC DICOMweb URLs are not committed; Firebase deploys pass
+`SLIM_PREVIEW_DICOMWEB_URL` via GitHub Actions secret or variable
+([deploy-to-firebase](../.github/workflows/deploy-to-firebase.yml)).
+
 For the full type definitions, see [`src/AppConfig.d.ts`](../src/AppConfig.d.ts).
 Example configs live in [`public/config/`](../public/config/).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,13 +10,12 @@ start time with the `REACT_APP_CONFIG` environment variable (defaults to
 Copy [`.env.example`](../.env.example) for documented defaults. The repo ships a
 tracked `.env` with `REACT_APP_CONFIG=local`. Using `SLIM_*` env vars is
 optional: config files under `public/config/` may hardcode server URLs as usual.
-Put private `SLIM_*` values in gitignored `.env.local`. Start/build writes them
-to `public/config/env.js` as `window.slim.env` (see
-`scripts/inject-slim-env.mjs`), and any config can read them (for example
-`url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL`). Slim’s own `preview.js` uses
-env so IDC DICOMweb URLs are not committed; Firebase deploys pass
-`SLIM_PREVIEW_DICOMWEB_URL` via GitHub Actions secret or variable
-([deploy-to-firebase](../.github/workflows/deploy-to-firebase.yml)).
+If you want to keep URLs out of the codebase, put `SLIM_*` values in gitignored
+`.env.local`. Start/build writes them to `public/config/env.js` as
+`window.slim.env` (see `scripts/inject-slim-env.mjs`), and any config can read
+them (for example `url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL`). Firebase
+deploys can pass `SLIM_PREVIEW_DICOMWEB_URL` via a GitHub Actions secret or
+variable ([deploy-to-firebase](../.github/workflows/deploy-to-firebase.yml)).
 
 For the full type definitions, see [`src/AppConfig.d.ts`](../src/AppConfig.d.ts).
 Example configs live in [`public/config/`](../public/config/).

--- a/public/config/demo.js
+++ b/public/config/demo.js
@@ -3,7 +3,7 @@ window.config = {
   servers: [
     {
       id: 'demo',
-      url: 'https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs',
+      url: window.slim.env.SLIM_DEMO_DICOMWEB_URL,
       write: false
     }
   ],

--- a/public/config/local.js
+++ b/public/config/local.js
@@ -5,7 +5,7 @@ window.config = {
     {
       id: 'local',
       // This must match the proxy location configured for the web server
-      url: 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
+      url: window.slim.env.SLIM_LOCAL_DICOMWEB_URL,
       write: true
     }
   ],

--- a/public/config/preview.js
+++ b/public/config/preview.js
@@ -3,7 +3,7 @@ window.config = {
   servers: [
     {
       id: 'preview',
-      url: 'https://testing-proxy.canceridc.dev/current/viewer-only-no-downloads-see-tinyurl-dot-com-slash-3j3d9jyp/dicomWeb',
+      url: window.slim.env.SLIM_PREVIEW_DICOMWEB_URL,
       write: false
     }
   ],

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,8 @@
       content="Slide Microscopy Viewer"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!-- Application Configuration -->
+    <!-- Application Configuration. Optional SLIM_* vars → window.slim.env via env.js -->
+    <script type="text/javascript" src="%PUBLIC_URL%/config/env.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/config/%REACT_APP_CONFIG%.js"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/scripts/inject-slim-env.mjs
+++ b/scripts/inject-slim-env.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /**
  * Writes public/config/env.js from process env + .env.
- * Optional: configs may hardcode values, or read window.slim.env.VAR_NAME.
- * Only SLIM_* keys are exported onto window.slim.env.
+ * Configs read window.slim.env.VAR_NAME. Only SLIM_* keys are exported.
  */
 import fs from 'node:fs'
 import path from 'node:path'
@@ -10,6 +9,12 @@ import { fileURLToPath } from 'node:url'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const outPath = path.join(root, 'public/config/env.js')
+
+const requiredUrlByConfig = {
+  local: 'SLIM_LOCAL_DICOMWEB_URL',
+  demo: 'SLIM_DEMO_DICOMWEB_URL',
+  preview: 'SLIM_PREVIEW_DICOMWEB_URL',
+}
 
 function loadDotEnvInto(file, target) {
   if (!fs.existsSync(file)) {
@@ -36,7 +41,6 @@ function loadDotEnvInto(file, target) {
   }
 }
 
-// Existing process.env wins over .env.
 const fileValues = {}
 loadDotEnvInto(path.join(root, '.env'), fileValues)
 
@@ -54,9 +58,10 @@ for (const [key, value] of Object.entries(process.env)) {
 }
 
 const configName = process.env.REACT_APP_CONFIG || 'local'
-if (configName === 'preview' && !slimEnv.SLIM_PREVIEW_DICOMWEB_URL) {
+const requiredKey = requiredUrlByConfig[configName]
+if (requiredKey && !slimEnv[requiredKey]) {
   console.error(
-    'SLIM_PREVIEW_DICOMWEB_URL is required when REACT_APP_CONFIG=preview (set in .env or CI).'
+    `${requiredKey} is required when REACT_APP_CONFIG=${configName} (set in .env or CI).`
   )
   process.exit(1)
 }

--- a/scripts/inject-slim-env.mjs
+++ b/scripts/inject-slim-env.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Writes public/config/env.js from process env + .env / .env.local.
+ * Optional: configs may hardcode values, or read window.slim.env.VAR_NAME.
+ * Only SLIM_* keys are exported onto window.slim.env.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const outPath = path.join(root, 'public/config/env.js')
+
+function loadDotEnvInto(file, target) {
+  if (!fs.existsSync(file)) {
+    return
+  }
+  for (const line of fs.readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) {
+      continue
+    }
+    const key = trimmed.slice(0, eq).trim()
+    let val = trimmed.slice(eq + 1).trim()
+    if (
+      (val.startsWith("'") && val.endsWith("'")) ||
+      (val.startsWith('"') && val.endsWith('"'))
+    ) {
+      val = val.slice(1, -1)
+    }
+    target[key] = val
+  }
+}
+
+// Match CRA local file order: .env then .env.local. Existing process.env wins.
+const fileValues = {}
+loadDotEnvInto(path.join(root, '.env'), fileValues)
+loadDotEnvInto(path.join(root, '.env.local'), fileValues)
+
+for (const [key, value] of Object.entries(fileValues)) {
+  if (process.env[key] === undefined) {
+    process.env[key] = value
+  }
+}
+
+const slimEnv = {}
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith('SLIM_') && value !== undefined && value !== '') {
+    slimEnv[key] = value
+  }
+}
+
+const configName = process.env.REACT_APP_CONFIG || 'local'
+if (configName === 'preview' && !slimEnv.SLIM_PREVIEW_DICOMWEB_URL) {
+  console.error(
+    'SLIM_PREVIEW_DICOMWEB_URL is required when REACT_APP_CONFIG=preview (set in .env.local or CI).'
+  )
+  process.exit(1)
+}
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(
+  outPath,
+  [
+    'window.slim = window.slim || {}',
+    `window.slim.env = ${JSON.stringify(slimEnv, null, 2)}`,
+    '',
+  ].join('\n')
+)

--- a/scripts/inject-slim-env.mjs
+++ b/scripts/inject-slim-env.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Writes public/config/env.js from process env + .env.
- * Configs read window.slim.env.VAR_NAME. Only SLIM_* keys are exported.
+ * Configs read window.slim.env.VAR_NAME.
+ * Only an allowlisted set of SLIM_* keys is exported (avoids leaking unrelated secrets).
  */
 import fs from 'node:fs'
 import path from 'node:path'
@@ -12,6 +13,12 @@ const outPath = path.join(root, 'public/config/env.js')
 
 const DEFAULT_LOCAL_DICOMWEB_URL =
   'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
+
+const ALLOWED_SLIM_ENV_KEYS = [
+  'SLIM_LOCAL_DICOMWEB_URL',
+  'SLIM_DEMO_DICOMWEB_URL',
+  'SLIM_PREVIEW_DICOMWEB_URL',
+]
 
 const requiredUrlByConfig = {
   local: 'SLIM_LOCAL_DICOMWEB_URL',
@@ -59,8 +66,9 @@ if (!process.env.SLIM_LOCAL_DICOMWEB_URL) {
 }
 
 const slimEnv = {}
-for (const [key, value] of Object.entries(process.env)) {
-  if (key.startsWith('SLIM_') && value !== undefined && value !== '') {
+for (const key of ALLOWED_SLIM_ENV_KEYS) {
+  const value = process.env[key]
+  if (value !== undefined && value !== '') {
     slimEnv[key] = value
   }
 }

--- a/scripts/inject-slim-env.mjs
+++ b/scripts/inject-slim-env.mjs
@@ -10,6 +10,9 @@ import { fileURLToPath } from 'node:url'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const outPath = path.join(root, 'public/config/env.js')
 
+const DEFAULT_LOCAL_DICOMWEB_URL =
+  'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
+
 const requiredUrlByConfig = {
   local: 'SLIM_LOCAL_DICOMWEB_URL',
   demo: 'SLIM_DEMO_DICOMWEB_URL',
@@ -50,6 +53,11 @@ for (const [key, value] of Object.entries(fileValues)) {
   }
 }
 
+// Safe public default for docker-compose / fresh clones / CI unit builds.
+if (!process.env.SLIM_LOCAL_DICOMWEB_URL) {
+  process.env.SLIM_LOCAL_DICOMWEB_URL = DEFAULT_LOCAL_DICOMWEB_URL
+}
+
 const slimEnv = {}
 for (const [key, value] of Object.entries(process.env)) {
   if (key.startsWith('SLIM_') && value !== undefined && value !== '') {
@@ -60,8 +68,13 @@ for (const [key, value] of Object.entries(process.env)) {
 const configName = process.env.REACT_APP_CONFIG || 'local'
 const requiredKey = requiredUrlByConfig[configName]
 if (requiredKey && !slimEnv[requiredKey]) {
+  const ciHint =
+    requiredKey === 'SLIM_DEMO_DICOMWEB_URL' ||
+    requiredKey === 'SLIM_PREVIEW_DICOMWEB_URL'
+      ? ` Set GitHub Actions secret or variable ${requiredKey}, or add it to .env.`
+      : ' Set it in .env (see .env.example).'
   console.error(
-    `${requiredKey} is required when REACT_APP_CONFIG=${configName} (set in .env or CI).`
+    `${requiredKey} is required when REACT_APP_CONFIG=${configName}.${ciHint}`
   )
   process.exit(1)
 }

--- a/scripts/inject-slim-env.mjs
+++ b/scripts/inject-slim-env.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Writes public/config/env.js from process env + .env / .env.local.
+ * Writes public/config/env.js from process env + .env.
  * Optional: configs may hardcode values, or read window.slim.env.VAR_NAME.
  * Only SLIM_* keys are exported onto window.slim.env.
  */
@@ -36,10 +36,9 @@ function loadDotEnvInto(file, target) {
   }
 }
 
-// Match CRA local file order: .env then .env.local. Existing process.env wins.
+// Existing process.env wins over .env.
 const fileValues = {}
 loadDotEnvInto(path.join(root, '.env'), fileValues)
-loadDotEnvInto(path.join(root, '.env.local'), fileValues)
 
 for (const [key, value] of Object.entries(fileValues)) {
   if (process.env[key] === undefined) {
@@ -57,7 +56,7 @@ for (const [key, value] of Object.entries(process.env)) {
 const configName = process.env.REACT_APP_CONFIG || 'local'
 if (configName === 'preview' && !slimEnv.SLIM_PREVIEW_DICOMWEB_URL) {
   console.error(
-    'SLIM_PREVIEW_DICOMWEB_URL is required when REACT_APP_CONFIG=preview (set in .env.local or CI).'
+    'SLIM_PREVIEW_DICOMWEB_URL is required when REACT_APP_CONFIG=preview (set in .env or CI).'
   )
   process.exit(1)
 }

--- a/scripts/resolve-dmv-preview-branch.sh
+++ b/scripts/resolve-dmv-preview-branch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DMV_REPO='https://github.com/ImagingDataCommons/dicom-microscopy-viewer.git'
+
+is_safe_ref() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._/-]*|.*|*.) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Strip HTML comments so PR-template examples cannot be parsed as values.
+BODY_NO_COMMENTS="$(python3 -c 'import os,re; print(re.sub(r"<!--.*?-->", "", os.environ.get("PR_BODY", ""), flags=re.S))')"
+
+# Prefer explicit "dmv-branch: <name>" from the PR body; else same-name branch.
+EXPLICIT=""
+while IFS= read -r line || [ -n "${line}" ]; do
+  case "${line}" in
+    dmv-branch:*)
+      val="${line#dmv-branch:}"
+      val="$(printf '%s' "${val}" | tr -d '[:space:]')"
+      if [ -n "${val}" ]; then
+        EXPLICIT="${val}"
+      fi
+      ;;
+  esac
+done < <(printf '%s\n' "${BODY_NO_COMMENTS}" | sed -nE 's/^[[:space:]]*(dmv-branch:.*)$/\1/p')
+
+if [ -n "${EXPLICIT}" ]; then
+  BRANCH="${EXPLICIT}"
+  SOURCE='dmv-branch'
+else
+  BRANCH="${HEAD_REF}"
+  SOURCE='matching-branch'
+fi
+
+if ! is_safe_ref "${BRANCH}"; then
+  echo "::error::Unsafe DMV branch ref rejected: ${BRANCH}"
+  exit 1
+fi
+
+SHA="$(git ls-remote --heads "${DMV_REPO}" "refs/heads/${BRANCH}" | awk '{print $1}')"
+if [ -n "${SHA}" ]; then
+  case "${SHA}" in
+    *[!0-9a-fA-F]*|'' ) echo "::error::Unexpected git SHA from ls-remote"; exit 1 ;;
+  esac
+  echo "Using DMV branch '${BRANCH}' (${SOURCE}) at ${SHA}"
+  {
+    echo "use_git=true"
+    echo "ref=${BRANCH}"
+    echo "sha=${SHA}"
+    echo "source=${SOURCE}"
+  } >> "${GITHUB_OUTPUT}"
+elif [ -n "${EXPLICIT}" ]; then
+  echo "::error::dmv-branch '${EXPLICIT}' was set in the PR body but was not found on dicom-microscopy-viewer"
+  exit 1
+else
+  echo "No matching DMV branch '${BRANCH}'; using package.json pin"
+  echo "use_git=false" >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/set-git-env.sh
+++ b/scripts/set-git-env.sh
@@ -6,18 +6,22 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SLIM_ROOT="$(dirname "$SCRIPT_DIR")"
 DMV_DIR="$(dirname "$SLIM_ROOT")/dicom-microscopy-viewer"
 
-# Get current repository git SHA
-if [ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1; then
-  export REACT_APP_GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo '')
-else
-  export REACT_APP_GIT_SHA=''
+# Get current repository git SHA (do not clobber a value already set in CI).
+if [ -z "${REACT_APP_GIT_SHA:-}" ]; then
+  if [ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1; then
+    export REACT_APP_GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo '')
+  else
+    export REACT_APP_GIT_SHA=''
+  fi
 fi
 
-# Get dicom-microscopy-viewer git SHA (when present as sibling of slim)
-if [ -d "$DMV_DIR/.git" ] || (cd "$DMV_DIR" 2>/dev/null && git rev-parse --git-dir > /dev/null 2>&1); then
-  export REACT_APP_DMV_GIT_SHA=$(cd "$DMV_DIR" && git rev-parse HEAD 2>/dev/null || echo '')
-else
-  export REACT_APP_DMV_GIT_SHA=''
+# Get dicom-microscopy-viewer git SHA (sibling checkout, or leave CI-provided value).
+if [ -z "${REACT_APP_DMV_GIT_SHA:-}" ]; then
+  if [ -d "$DMV_DIR/.git" ] || (cd "$DMV_DIR" 2>/dev/null && git rev-parse --git-dir > /dev/null 2>&1); then
+    export REACT_APP_DMV_GIT_SHA=$(cd "$DMV_DIR" && git rev-parse HEAD 2>/dev/null || echo '')
+  else
+    export REACT_APP_DMV_GIT_SHA=''
+  fi
 fi
 
 # Default config name when .env is absent (fresh clone).

--- a/scripts/set-git-env.sh
+++ b/scripts/set-git-env.sh
@@ -20,6 +20,9 @@ else
   export REACT_APP_DMV_GIT_SHA=''
 fi
 
+# Default config name when .env is absent (fresh clone).
+export REACT_APP_CONFIG="${REACT_APP_CONFIG:-local}"
+
 # Expose SLIM_* env vars to public/config/*.js via window.slim.env
 node "$SCRIPT_DIR/inject-slim-env.mjs" || exit $?
 

--- a/scripts/set-git-env.sh
+++ b/scripts/set-git-env.sh
@@ -20,6 +20,9 @@ else
   export REACT_APP_DMV_GIT_SHA=''
 fi
 
+# Expose SLIM_* env vars to public/config/*.js via window.slim.env
+node "$SCRIPT_DIR/inject-slim-env.mjs" || exit $?
+
 # Execute the command passed as arguments
 exec "$@"
 


### PR DESCRIPTION
## Summary
- Committed `public/config/{local,demo,preview}.js` read DICOMweb URLs from allowlisted `window.slim.env` keys
- Single gitignored `.env` (see `.env.example`); local URL soft-defaults for Docker/CI/forks
- Firebase PR previews can install DMV from git: prefer `dmv-branch:` in the PR body, else same-named branch
- **Security:** validate DMV refs, no shell interpolation of user-controlled refs, `pnpm install --ignore-scripts` + explicit `pnpm rebuild` for DMV/core-js
- **Retrigger:** editing the PR **body** (e.g. add `dmv-branch:`) re-runs Firebase preview; title-only edits are ignored
- OHIF-style PR template + contributor docs

## Before merge (maintainers)
- [ ] Set Actions secret or variable `SLIM_PREVIEW_DICOMWEB_URL`
- [ ] Set Actions secret or variable `SLIM_DEMO_DICOMWEB_URL`

## Test plan
- [ ] No `.env`: `pnpm start` / `pnpm build` still work (local default URL)
- [ ] `docker compose up` builds the app image
- [ ] Unit-test / container / Firebase / GH Pages checks pass
- [ ] Sonar script-injection / install-scripts findings clear or accepted
- [ ] Open PR without `dmv-branch`, then edit body to add `dmv-branch: <existing-dmv-branch>` → preview redeploys against that DMV
- [ ] Title-only PR edit does not redeploy
