### PR TITLE
fix(ci): escape hyphens in pnpm pkg set property path

### DIFF
--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -66,7 +66,7 @@ jobs:
                 exit 1
                 ;;
             esac
-            pnpm pkg set "dependencies.dicom-microscopy-viewer=github:ImagingDataCommons/dicom-microscopy-viewer#${DMV_REF}"
+            pnpm pkg set 'dependencies["dicom-microscopy-viewer"]'"=github:ImagingDataCommons/dicom-microscopy-viewer#${DMV_REF}"
             pnpm install --no-frozen-lockfile --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary
Fixes the Firebase deploy workflow failure caused by `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`.

The `pnpm pkg set` command uses dot notation for property paths. Property names containing hyphens (like `dicom-microscopy-viewer`) must use bracket notation to be parsed correctly.

**Before:**
```bash
pnpm pkg set "dependencies.dicom-microscopy-viewer=..."
```

**After:**
```bash
pnpm pkg set 'dependencies["dicom-microscopy-viewer"]'="..."
```

## Test plan
- [ ] Firebase deploy workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)