### PR TITLE
fix(ci): build DMV when using git dependency from package.json

### DIFF
--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -97,16 +97,47 @@ jobs:
           REACT_APP_DMV_GIT_SHA: ${{ steps.dmv.outputs.sha }}
         run: pnpm run build
 
-      - name: Note DMV source on PR
-        if: github.event_name == 'pull_request' && steps.dmv.outputs.use_git == 'true'
+      - name: Comment DMV status on PR
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          DMV_USE_GIT: ${{ steps.dmv.outputs.use_git }}
           DMV_REF: ${{ steps.dmv.outputs.ref }}
           DMV_SHA: ${{ steps.dmv.outputs.sha }}
           DMV_SOURCE: ${{ steps.dmv.outputs.source }}
         run: |
-          gh pr comment "${PR_NUMBER}" --body "Firebase preview uses dicom-microscopy-viewer branch ${DMV_REF} (${DMV_SHA}, via ${DMV_SOURCE})."
+          if [ "${DMV_USE_GIT}" = "true" ]; then
+            BODY="$(cat <<EOF
+          ## 🔗 Firebase Preview - Linked to DMV Branch
+
+          This preview is using a **linked** \`dicom-microscopy-viewer\` branch:
+
+          | | |
+          |---|---|
+          | **Branch** | [\`${DMV_REF}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/tree/${DMV_REF}) |
+          | **Commit** | [\`${DMV_SHA:0:7}\`](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/commit/${DMV_SHA}) |
+          | **Source** | \`${DMV_SOURCE}\` |
+
+          > To change the DMV branch, edit \`dmv-branch: <branch-name>\` in the PR description.
+          EOF
+          )"
+          else
+            DMV_VERSION="$(node -p "require('./package.json').dependencies['dicom-microscopy-viewer']")"
+            BODY="$(cat <<EOF
+          ## 📦 Firebase Preview - Using Published DMV
+
+          This preview is using the **published** \`dicom-microscopy-viewer\` from package.json:
+
+          | | |
+          |---|---|
+          | **Version** | \`${DMV_VERSION}\` |
+
+          > To link a DMV branch for testing, add \`dmv-branch: <branch-name>\` to the PR description (requires an open PR in DMV).
+          EOF
+          )"
+          fi
+          gh pr comment "${PR_NUMBER}" --body "${BODY}"
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -47,6 +47,7 @@ jobs:
         id: dmv
         if: github.event_name == 'pull_request'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
           HEAD_REF: ${{ github.head_ref }}
         run: ./scripts/resolve-dmv-preview-branch.sh

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -73,6 +73,11 @@ jobs:
           fi
           # allowBuilds in pnpm-workspace.yaml: core-js(+pure) and dicom-microscopy-viewer
           pnpm rebuild dicom-microscopy-viewer core-js core-js-pure
+          # Build DMV if dist files are missing (git dependency in package.json)
+          if [ ! -f "node_modules/dicom-microscopy-viewer/dist/dynamic-import/dicomMicroscopyViewer.min.js" ]; then
+            echo "DMV dist files missing - building from git dependency"
+            pnpm --filter dicom-microscopy-viewer run build
+          fi
 
       - name: Require preview DICOMweb URL
         env:

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -133,7 +133,9 @@ jobs:
           |---|---|
           | **Version** | \`${DMV_VERSION}\` |
 
-          > To link a DMV branch for testing, add \`dmv-branch: <branch-name>\` to the PR description (requires an open PR in DMV).
+          > **To link a DMV branch for testing** (requires an open PR in DMV):
+          > - Add \`dmv-branch: <branch-name>\` to the PR description, OR
+          > - Use the same branch name in both repos (automatic matching)
           EOF
           )"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,20 +73,33 @@ Use the repository pull request template. Include a clear summary, testing notes
 
 If your Slim change depends on an unreleased
 [dicom-microscopy-viewer](https://github.com/ImagingDataCommons/dicom-microscopy-viewer)
-branch, the Firebase preview workflow can install that branch automatically:
+branch, the Firebase preview workflow can install that branch automatically.
 
-1. **Explicit:** add a line near the top of the PR body (template field):
+There are **two ways** to link a DMV branch (both require an open PR in DMV):
+
+1. **Explicit `dmv-branch:`** — add a line near the top of the PR body:
 
    ```text
    dmv-branch: feat/my-dmv-change
    ```
 
-2. **Same name:** use the same branch name in both repos (for example both
-   `feat/my-change`) and leave `dmv-branch` empty.
+2. **Matching branch name** — use the same branch name in both repos (for example
+   `feat/my-change` in both Slim and DMV). No configuration needed — the workflow
+   detects matching branches automatically.
 
-`dmv-branch` wins when set. If it points at a branch that does not exist on DMV,
-the preview job fails. If neither option applies, the preview uses the npm pin
-from `package.json`.
+If both methods apply, `dmv-branch:` takes priority. If neither applies, the
+preview uses the published npm version from `package.json`.
+
+#### PR comments
+
+The workflow automatically posts a comment on your PR indicating which DMV
+version the Firebase preview is using:
+
+- **Linked to DMV Branch** — shows the branch name, commit SHA, and source
+  (explicit `dmv-branch:` or matching branch name)
+- **Using Published DMV** — shows the version from `package.json`
+
+#### Retriggering the preview
 
 Editing the PR description to add or change `dmv-branch:` retriggers the Firebase
 preview workflow (body edits only; title-only edits are ignored).


### PR DESCRIPTION
## Summary
Three improvements for DMV branch handling in Firebase previews:

### 1. Add GH_TOKEN to resolve DMV branch step
The `has_open_pr` function uses `gh pr list` which requires authentication. Without `GH_TOKEN`, the check always failed.

### 2. Build DMV when using git dependency from package.json
When DMV is installed from a git dependency in package.json (not via `dmv-branch:` or matching branch), the dist files still need to be built. Added a check after `pnpm rebuild` to build DMV if dist files are missing.

### 3. Clear PR comment showing DMV preview status
Replaces the simple one-line comment with a formatted status:

**When linked to DMV branch:**
> ## 🔗 Firebase Preview - Linked to DMV Branch
> | | |
> |---|---|
> | **Branch** | `feat/example` |
> | **Commit** | `abc1234` |
> | **Source** | `dmv-branch` |

**When using published DMV:**
> ## 📦 Firebase Preview - Using Published DMV
> | | |
> |---|---|
> | **Version** | `^0.48.23` |

## Test plan
- [ ] PR with `dmv-branch:` pointing to open DMV PR uses the git branch and shows linked comment
- [ ] PR without `dmv-branch:` shows published DMV comment
- [ ] PR with git dependency for DMV in package.json builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)