### PR TITLE
ci: dynamically allow DMV git tarball builds

### DIFF
--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           DMV_USE_GIT: ${{ steps.dmv.outputs.use_git }}
           DMV_REF: ${{ steps.dmv.outputs.ref }}
+          DMV_SHA: ${{ steps.dmv.outputs.sha }}
         run: |
           set -euo pipefail
           if [ "${DMV_USE_GIT}" = "true" ]; then
@@ -68,6 +69,19 @@ jobs:
                 ;;
             esac
             pnpm pkg set 'dependencies["dicom-microscopy-viewer"]'"=github:ImagingDataCommons/dicom-microscopy-viewer#${DMV_REF}"
+            # Dynamically allow builds for the resolved tarball URL so pnpm's
+            # dependency status check passes during `pnpm run build`
+            TARBALL_KEY="dicom-microscopy-viewer@https://codeload.github.com/ImagingDataCommons/dicom-microscopy-viewer/tar.gz/${DMV_SHA}"
+            node -e "
+              const fs = require('fs');
+              const content = fs.readFileSync('pnpm-workspace.yaml', 'utf8');
+              // Insert the tarball allowBuilds entry after 'dicom-microscopy-viewer: true'
+              const updated = content.replace(
+                /(allowBuilds:[\s\S]*?dicom-microscopy-viewer: true)/,
+                \"\$1\\n  '\" + process.argv[1] + \"': true\"
+              );
+              fs.writeFileSync('pnpm-workspace.yaml', updated);
+            " "${TARBALL_KEY}"
             pnpm install --no-frozen-lockfile --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ strictPeerDependencies: false
 allowBuilds:
   core-js: true
   core-js-pure: true
+  # For npm-published versions; git tarball URLs are added dynamically by CI
   dicom-microscopy-viewer: true
 
 overrides:


### PR DESCRIPTION
## Summary

- Dynamically insert the resolved DMV commit SHA into `pnpm-workspace.yaml`'s `allowBuilds` during CI
- Fixes pnpm 11's dependency status check failing when using git-hosted `dicom-microscopy-viewer`

### Problem

pnpm 11 introduced a security feature that blocks build scripts from dependencies by default. When the Firebase preview workflow resolves a DMV branch to a specific commit SHA, pnpm stores it as `dicom-microscopy-viewer@https://codeload.github.com/.../tar.gz/<SHA>`. The static `allowBuilds: dicom-microscopy-viewer: true` entry only matches npm-published versions, not git tarballs.

Previously, this required hardcoding the SHA in `pnpm-workspace.yaml`, which went stale whenever the DMV branch got new commits.

### Solution

The workflow now dynamically inserts the resolved tarball URL into `allowBuilds` before running `pnpm install`, so any DMV commit SHA is automatically approved.

## Test plan

- [x] Local pre-push hooks pass (lint, typecheck, build, tests)
- [ ] CI passes on this PR
- [ ] Verify PR #405 passes after merging this fix

🤖 Generated with [Claude Code](https://claude.ai/code)