### PR TITLE
fix(ci): run DMV build in node_modules directory

### DIFF
--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -91,7 +91,7 @@ jobs:
           # Build DMV if dist files are missing (git dependency in package.json)
           if [ ! -f "node_modules/dicom-microscopy-viewer/dist/dynamic-import/dicomMicroscopyViewer.min.js" ]; then
             echo "DMV dist files missing - building from git dependency"
-            pnpm --filter dicom-microscopy-viewer run build
+            (cd node_modules/dicom-microscopy-viewer && pnpm run build)
           fi
 
       - name: Require preview DICOMweb URL


### PR DESCRIPTION
## Summary

Fixes the DMV build command in the Firebase deploy workflow. `pnpm --filter` only works for workspace projects, not dependencies in `node_modules`.

### Problem

The previous command `pnpm --filter dicom-microscopy-viewer run build` fails with:
```
No projects matched the filters in "/home/runner/work/slim/slim"
```

### Solution

Run the build directly in the node_modules directory:
```bash
(cd node_modules/dicom-microscopy-viewer && pnpm run build)
```

## Test plan

- [x] Local pre-push hooks pass
- [ ] CI passes on this PR
- [ ] PR #405 passes after merging this fix and rebasing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>