### PR TITLE
feat: add fill toggle and opacity slider for bulk annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "classnames": "^2.2.6",
     "dcmjs": "^0.35.0",
     "detect-browser": "^5.2.1",
-    "dicom-microscopy-viewer": "^0.48.22",
+    "dicom-microscopy-viewer": "^0.48.24",
     "dicomweb-client": "0.10.3",
     "oidc-client": "^1.11.5",
     "ol": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^5.2.1
         version: 5.3.0
       dicom-microscopy-viewer:
-        specifier: ^0.48.22
-        version: 0.48.23
+        specifier: ^0.48.24
+        version: 0.48.24
       dicomweb-client:
         specifier: 0.10.3
         version: 0.10.3
@@ -2637,11 +2637,14 @@ packages:
     engines: {node: '>= 4.2.1'}
     hasBin: true
 
-  dicom-microscopy-viewer@0.48.23:
-    resolution: {integrity: sha512-ZC3evLO0EEQyp8E6rT6VVsL5VJLqxyyPUZct2y4MBi2MTkHkR/yWEJn7wu8pTas8uC93ULWDxim5xqRa0s4/eQ==}
+  dicom-microscopy-viewer@0.48.24:
+    resolution: {integrity: sha512-016o/23eNqXMxgX5EjnDmFz1ROSMQmU7vmRlTVPUgshl6NaBrZzEyWkzq4BNaFFPfrE274AWdR5crW51cWh+9g==}
 
   dicomweb-client@0.10.3:
     resolution: {integrity: sha512-/fHNEAYiz8j+9TNOrNJ0k+hYqirbOT85B7vM7I4VkY8DeDQb4BDUeL3RX6huDVtn6ZQlR91dI+2tejLc5c99wA==}
+
+  dicomweb-client@0.11.3:
+    resolution: {integrity: sha512-7t1Rc/01fyFnKlQeNPW9Pvxvmsx8R/BgB2n7BxTuWirRFwlTC5upEeLeS3vO72P+n6/SQZ3+5ij0bgaWDHQG/A==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -9422,7 +9425,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dicom-microscopy-viewer@0.48.23:
+  dicom-microscopy-viewer@0.48.24:
     dependencies:
       '@cornerstonejs/codec-charls': 1.2.3
       '@cornerstonejs/codec-libjpeg-turbo-8bit': 1.2.2
@@ -9431,13 +9434,15 @@ snapshots:
       '@imagingdatacommons/dicomicc': 0.2.3
       colormap: 2.3.2
       dcmjs: 0.41.0
-      dicomweb-client: 0.10.3
+      dicomweb-client: 0.11.3
       image-type: 4.1.0
       mathjs: 11.12.0
       ol: 10.9.0
       uuid: 9.0.1
 
   dicomweb-client@0.10.3: {}
+
+  dicomweb-client@0.11.3: {}
 
   didyoumean@1.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,5 +40,5 @@ overrides:
   underscore: 1.13.8
 
 minimumReleaseAgeExclude:
-  - dicom-microscopy-viewer@0.48.23
+  - dicom-microscopy-viewer@0.48.23 || 0.48.24
   - dicomweb-client@0.11.3

--- a/src/components/AnnotationGroupItem.tsx
+++ b/src/components/AnnotationGroupItem.tsx
@@ -149,6 +149,8 @@ interface AnnotationGroupItemProps {
   defaultStyle: {
     opacity: number
     color: number[]
+    fill?: boolean
+    fillOpacity?: number
   }
   onAnnotationGroupClick: (annotationGroupUID: string) => void
   onVisibilityChange: ({
@@ -168,6 +170,8 @@ interface AnnotationGroupItemProps {
       color?: number[]
       limitValues?: number[]
       measurement?: dcmjs.sr.coding.CodedConcept
+      fill?: boolean
+      fillOpacity?: number
     }
   }) => void
 }
@@ -179,6 +183,8 @@ interface AnnotationGroupItemState {
     color?: number[]
     limitValues?: number[]
     measurement?: dcmjs.sr.coding.CodedConcept
+    fill?: boolean
+    fillOpacity?: number
   }
 }
 
@@ -197,6 +203,8 @@ class AnnotationGroupItem extends React.Component<
       currentStyle: {
         opacity: this.props.defaultStyle.opacity,
         color: this.props.defaultStyle.color,
+        fill: this.props.defaultStyle.fill ?? false,
+        fillOpacity: this.props.defaultStyle.fillOpacity ?? 0.5,
       },
     }
   }
@@ -215,9 +223,8 @@ class AnnotationGroupItem extends React.Component<
   handleColorChange = (color: number[]): void => {
     this.setState((state) => ({
       currentStyle: {
+        ...state.currentStyle,
         color,
-        opacity: state.currentStyle.opacity,
-        limitValues: state.currentStyle.limitValues,
       },
     }))
     this.props.onStyleChange({
@@ -234,13 +241,44 @@ class AnnotationGroupItem extends React.Component<
           opacity,
         },
       })
-      this.setState({
+      this.setState((state) => ({
         currentStyle: {
+          ...state.currentStyle,
           opacity,
-          color: this.state.currentStyle.color,
-          limitValues: this.state.currentStyle.limitValues,
+        },
+      }))
+    }
+  }
+
+  handleFillChange = (checked: boolean): void => {
+    this.props.onStyleChange({
+      uid: this.props.annotationGroup.uid,
+      styleOptions: {
+        fill: checked,
+      },
+    })
+    this.setState((state) => ({
+      currentStyle: {
+        ...state.currentStyle,
+        fill: checked,
+      },
+    }))
+  }
+
+  handleFillOpacityChange = (fillOpacity: number | null): void => {
+    if (fillOpacity !== null) {
+      this.props.onStyleChange({
+        uid: this.props.annotationGroup.uid,
+        styleOptions: {
+          fillOpacity,
         },
       })
+      this.setState((state) => ({
+        currentStyle: {
+          ...state.currentStyle,
+          fillOpacity,
+        },
+      }))
     }
   }
 
@@ -272,19 +310,12 @@ class AnnotationGroupItem extends React.Component<
         if (state.currentStyle.limitValues !== undefined) {
           return {
             currentStyle: {
-              color: state.currentStyle.color,
-              opacity: state.currentStyle.opacity,
+              ...state.currentStyle,
               limitValues: [value, state.currentStyle.limitValues[1]],
             },
           }
         } else {
-          return {
-            currentStyle: {
-              color: state.currentStyle.color,
-              opacity: state.currentStyle.opacity,
-              limitValues: state.currentStyle.limitValues,
-            },
-          }
+          return { currentStyle: state.currentStyle }
         }
       })
       this.props.onStyleChange({
@@ -306,19 +337,12 @@ class AnnotationGroupItem extends React.Component<
         if (state.currentStyle.limitValues !== undefined) {
           return {
             currentStyle: {
-              color: state.currentStyle.color,
-              opacity: state.currentStyle.opacity,
+              ...state.currentStyle,
               limitValues: [state.currentStyle.limitValues[0], value],
             },
           }
         } else {
-          return {
-            currentStyle: {
-              color: state.currentStyle.color,
-              opacity: state.currentStyle.opacity,
-              limitValues: state.currentStyle.limitValues,
-            },
-          }
+          return { currentStyle: state.currentStyle }
         }
       })
       this.props.onStyleChange({
@@ -333,8 +357,7 @@ class AnnotationGroupItem extends React.Component<
   handleLimitChange = (values: number[]): void => {
     this.setState((state) => ({
       currentStyle: {
-        color: state.currentStyle.color,
-        opacity: state.currentStyle.opacity,
+        ...state.currentStyle,
         limitValues: values,
       },
     }))
@@ -375,7 +398,7 @@ class AnnotationGroupItem extends React.Component<
       })
       this.setState((state) => ({
         currentStyle: {
-          opacity: state.currentStyle.opacity,
+          ...state.currentStyle,
           measurement,
         },
       }))
@@ -388,7 +411,7 @@ class AnnotationGroupItem extends React.Component<
       })
       this.setState((state) => ({
         currentStyle: {
-          opacity: state.currentStyle.opacity,
+          ...state.currentStyle,
           color: this.props.defaultStyle.color,
           limitValues: undefined,
         },
@@ -548,6 +571,60 @@ class AnnotationGroupItem extends React.Component<
       )
     }
 
+    // Fill settings for POLYGON, RECTANGLE, ELLIPSE graphic types
+    let fillSettings: React.ReactNode
+    if (
+      item.GraphicType === 'POLYGON' ||
+      item.GraphicType === 'RECTANGLE' ||
+      item.GraphicType === 'ELLIPSE'
+    ) {
+      fillSettings = (
+        <>
+          <Divider plain>Fill</Divider>
+          <Row justify="start" align="middle" gutter={[8, 8]}>
+            <Col span={8}>Enable fill</Col>
+            <Col span={16}>
+              <Switch
+                size="small"
+                checked={this.state.currentStyle.fill ?? false}
+                onChange={this.handleFillChange}
+              />
+            </Col>
+          </Row>
+          <Row
+            justify="start"
+            align="middle"
+            gutter={[8, 8]}
+            style={{ marginTop: '8px' }}
+          >
+            <Col span={8}>Fill opacity</Col>
+            <Col span={12}>
+              <Slider
+                min={0}
+                max={1}
+                step={0.01}
+                value={this.state.currentStyle.fillOpacity ?? 0.5}
+                onChange={this.handleFillOpacityChange}
+                disabled={!this.state.currentStyle.fill}
+              />
+            </Col>
+            <Col span={4}>
+              <InputNumber
+                min={0}
+                max={1}
+                step={0.01}
+                size="small"
+                style={{ width: '55px' }}
+                value={this.state.currentStyle.fillOpacity ?? 0.5}
+                onChange={this.handleFillOpacityChange}
+                disabled={!this.state.currentStyle.fill}
+              />
+            </Col>
+          </Row>
+        </>
+      )
+    }
+
     const settings = (
       <div>
         {colorSettings}
@@ -556,6 +633,7 @@ class AnnotationGroupItem extends React.Component<
           opacity={this.state.currentStyle.opacity}
           onChange={this.handleOpacityChange}
         />
+        {fillSettings}
         {explorationSettings}
       </div>
     )

--- a/src/components/AnnotationGroupList.tsx
+++ b/src/components/AnnotationGroupList.tsx
@@ -18,6 +18,8 @@ interface AnnotationGroupListProps {
     [annotationGroupUID: string]: {
       opacity: number
       color: number[]
+      fill?: boolean
+      fillOpacity?: number
     }
   }
   onAnnotationGroupClick: (annotationGroupUID: string) => void
@@ -37,6 +39,8 @@ interface AnnotationGroupListProps {
       opacity?: number
       color?: number[]
       measurement?: dcmjs.sr.coding.CodedConcept
+      fill?: boolean
+      fillOpacity?: number
     }
   }) => void
 }

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -3008,6 +3008,8 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
       opacity?: number
       color?: number[]
       measurement?: dcmjs.sr.coding.CodedConcept
+      fill?: boolean
+      fillOpacity?: number
     }
   }): void => {
     logger.log(`change style of annotation group ${uid}`)


### PR DESCRIPTION
## Summary
- Add UI controls in the annotation group display settings for enabling fill on polygon annotations
- Toggle switch to enable/disable fill
- Opacity slider (0-1) that is disabled when fill is off
- Fill settings only shown for POLYGON, RECTANGLE, and ELLIPSE graphic types

## Changes
- **AnnotationGroupItem.tsx**: Added fill toggle, fill opacity slider, and handlers
- **AnnotationGroupList.tsx**: Updated interface to include fill style options
- **SlideViewer.tsx**: Updated style change handler to pass fill options to DMV

## Dependencies
- Requires dicom-microscopy-viewer PR: https://github.com/ImagingDataCommons/dicom-microscopy-viewer/pull/279

## Test plan
- [ ] Load a slide with bulk polygon annotations
- [ ] Open display settings for an annotation group with POLYGON graphic type
- [ ] Verify the Fill section appears with toggle and opacity controls
- [ ] Enable fill and verify polygons render with fill color
- [ ] Adjust fill opacity and verify the opacity changes
- [ ] Verify the fill opacity slider/input is disabled when fill is off
- [ ] Verify POINT and POLYLINE annotation groups do not show fill settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)