### PR TITLE
fix: prevent FRACTIONAL colormap from being replaced on opacity change

### DIFF
--- a/src/components/SegmentItem.tsx
+++ b/src/components/SegmentItem.tsx
@@ -99,11 +99,15 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
           return { currentStyle: newStyle }
         },
         () => {
+          /**
+           * Only send opacity - do not include color. For FRACTIONAL segments,
+           * sending color would replace the distinct colormap with a flat LUT.
+           * Color changes are handled separately by handleColorChange.
+           */
           this.props.onStyleChange({
             segmentUID: this.props.segment.uid,
             styleOptions: {
               opacity,
-              color: this.state.currentStyle.color,
             },
           })
         },


### PR DESCRIPTION
## Summary

Fix bug where FRACTIONAL segmentation colormaps get binarized (replaced with flat color LUT) when adjusting the opacity slider.

**Root cause:** `SegmentItem.handleOpacityChange` was always sending `color` along with `opacity` in the style options. For FRACTIONAL segments, this caused `SlideViewer.handleSegmentStyleChange` to create a new `paletteColorLookupTable` from that flat color, replacing the distinct colormap that was originally assigned.

**Fix:** `handleOpacityChange` now only sends `opacity`. Color changes are handled separately by `handleColorChange`, which is already hidden in the UI for FRACTIONAL segments.

## Test plan

- [ ] Load a FRACTIONAL segmentation (e.g., https://viewer.imaging.datacommons.cancer.gov/slim/studies/2.25.213661963103110408605329613498871186883/series/1.2.826.0.1.3680043.10.511.3.51628462607277482021421207939845935)
- [ ] Adjust the opacity slider
- [ ] Verify the distinct colormap is preserved (not replaced with flat color)
- [ ] Verify BINARY segments still allow color changes via the color slider

Fixes #428