### PR TITLE
Update README instructions to link dicom-microscopy-viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,21 +480,12 @@ If neither applies, the preview uses the version in `package.json`. Editing the 
 1. **Clone dicom-microscopy-viewer**  
    If you have not already, clone the `dicom-microscopy-viewer` repository to your machine.
 
-2. **Set up pnpm link in dicom-microscopy-viewer**  
-   In the root directory of your local `dicom-microscopy-viewer` repository, run:
-
-   ```bash
-   pnpm link --global
-   ```
-
-3. **Link dicom-microscopy-viewer in Slim**  
+2. **Link dicom-microscopy-viewer in Slim**
    In the root directory of your Slim project, run:
 
    ```bash
-   pnpm link dicom-microscopy-viewer
+   pnpm link <path-to-dicom-microscopy-viewer>
    ```
-
-   Do **not** run `pnpm link dicom-microscopy-viewer` inside the `dicom-microscopy-viewer` repo itself — only `pnpm link --global` belongs there.
 
    Verify the link points at your local clone (not the registry copy under `.pnpm`):
 
@@ -502,7 +493,7 @@ If neither applies, the preview uses the version in `package.json`. Editing the 
    node -e "console.log(require('fs').realpathSync('node_modules/dicom-microscopy-viewer'))"
    ```
 
-4. **Enable live rebuilding in dicom-microscopy-viewer**  
+3. **Enable live rebuilding in dicom-microscopy-viewer**
    In a separate terminal, in the `dicom-microscopy-viewer` directory, run:
 
    ```bash
@@ -511,7 +502,7 @@ If neither applies, the preview uses the version in `package.json`. Editing the 
 
    Slim imports the **built** `dist/dynamic-import` bundle, not `src/` directly. Wait for DMV watch to report `[emitted] dicomMicroscopyViewer.min.js` after each change.
 
-5. **Run Slim as usual**  
+4. **Run Slim as usual**
    In the Slim directory, start the development server:
 
    ```bash


### PR DESCRIPTION
### Context

The instructions for linking slim with a local clone of `dicom-microscopy-viewer` appear to be outdated.
Running `pnpm link --global` from the dicom-microscopy-viewer directory (as instructed in the current README) gives me:

```
[ERR_PNPM_LINK_BAD_PARAMS] You must provide a parameter. Usage: pnpm link <dir>
```

According to my colleague Claude this is old pnpm behavior back from pnpm versions v6-v8. The version used by slim now is 11.9.0, and expects different behavior. There is no global linking step, you just run `pnpm link /path/to/dicom-microscopy-viewer` straight from the slim repo root in single step.

### Changes & Results

This PR updates the README in line with the findings above


### Testing

Following the updated instructions allows me to run slim dev server with dicom-microscopy-viewer on my mac.