### PR TITLE
ci: improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -55,7 +56,7 @@ jobs:
           exit 1
 
       - name: Wildfly internal server.log
-        if: always()
+        if: failure()
         run: |
           docker cp dcm4chee-arc:/opt/wildfly/standalone/log/server.log ./server.log || echo "Log not found"
           cat ./server.log || echo "Log not found"

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -96,10 +96,10 @@ jobs:
 
       - name: Require preview DICOMweb URL
         env:
-          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
+          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL }}
         run: |
           if [ -z "${SLIM_PREVIEW_DICOMWEB_URL}" ]; then
-            echo "::error::Set Actions secret or variable SLIM_PREVIEW_DICOMWEB_URL (used by public/config/preview.js via window.slim.env)."
+            echo "::error::Set Actions secret SLIM_PREVIEW_DICOMWEB_URL (used by public/config/preview.js via window.slim.env)."
             exit 1
           fi
 
@@ -107,7 +107,7 @@ jobs:
         env:
           REACT_APP_CONFIG: preview
           PUBLIC_URL: /
-          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL || vars.SLIM_PREVIEW_DICOMWEB_URL }}
+          SLIM_PREVIEW_DICOMWEB_URL: ${{ secrets.SLIM_PREVIEW_DICOMWEB_URL }}
           REACT_APP_DMV_GIT_SHA: ${{ steps.dmv.outputs.sha }}
         run: pnpm run build
 
@@ -121,8 +121,10 @@ jobs:
           DMV_SHA: ${{ steps.dmv.outputs.sha }}
           DMV_SOURCE: ${{ steps.dmv.outputs.source }}
         run: |
+          MARKER="<!-- firebase-preview-dmv-status -->"
           if [ "${DMV_USE_GIT}" = "true" ]; then
             BODY="$(cat <<EOF
+          ${MARKER}
           ## 🔗 Firebase Preview - Linked to DMV Branch
 
           This preview is using a **linked** \`dicom-microscopy-viewer\` branch:
@@ -139,6 +141,7 @@ jobs:
           else
             DMV_VERSION="$(node -p "require('./package.json').dependencies['dicom-microscopy-viewer']")"
             BODY="$(cat <<EOF
+          ${MARKER}
           ## 📦 Firebase Preview - Using Published DMV
 
           This preview is using the **published** \`dicom-microscopy-viewer\` from package.json:
@@ -153,7 +156,14 @@ jobs:
           EOF
           )"
           fi
-          gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          EXISTING_COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+          if [ -n "${EXISTING_COMMENT_ID}" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_COMMENT_ID}" \
+              --method PATCH --field body="${BODY}"
+          else
+            gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          fi
 
       - name: Deploy preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -3,8 +3,6 @@ name: slim/deploy-to-github-pages
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -12,12 +10,10 @@ permissions:
 
 concurrency:
   group: deploy-gh-pages-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   deploy-to-github-pages:
-    # The check name "Deploy to GitHub Pages" is required by the master ruleset,
-    # so this job must also run (build-only) on pull requests.
     name: "Deploy to GitHub Pages"
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -41,22 +37,19 @@ jobs:
 
       - name: Require demo DICOMweb URL
         env:
-          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL || vars.SLIM_DEMO_DICOMWEB_URL }}
+          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL }}
         run: |
           if [ -z "${SLIM_DEMO_DICOMWEB_URL}" ]; then
-            echo "::error::Set Actions secret or variable SLIM_DEMO_DICOMWEB_URL (used by public/config/demo.js via window.slim.env)."
+            echo "::error::Set Actions secret SLIM_DEMO_DICOMWEB_URL (used by public/config/demo.js via window.slim.env)."
             exit 1
           fi
 
       - name: Build
         env:
-          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL || vars.SLIM_DEMO_DICOMWEB_URL }}
+          SLIM_DEMO_DICOMWEB_URL: ${{ secrets.SLIM_DEMO_DICOMWEB_URL }}
         run: pnpm run predeploy
 
-      # Only pushes to master (and manual runs) publish; pull requests stop
-      # after the build so unmerged code never overwrites the live demo site.
       - name: Deploy to GitHub Pages
-        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **deploy-to-github-pages**: Remove PR trigger since `unit-tests` already validates PRs with lint, typecheck, build, and test. Use secrets only, remove outdated PR-specific logic.
- **deploy-to-firebase**: Use secrets only (fork PRs are already skipped so vars fallback was unnecessary). Fix PR comment spam by updating existing comment instead of creating new ones.
- **unit-tests**: Add `workflow_dispatch` for manual re-runs.
- **container-tests**: Add `workflow_dispatch` for manual re-runs. Only dump Wildfly logs on failure to reduce noise.

## Test plan

- [ ] Verify unit-tests workflow can be manually triggered
- [ ] Verify container-tests workflow can be manually triggered
- [ ] Verify Firebase preview deploys correctly and updates existing PR comment
- [ ] Verify GitHub Pages deploys on push to master
- [ ] Remove "Deploy to GitHub Pages" from required checks in branch protection rules after merge