### PR TITLE
perf: pair Slim with DMV dead-tile skipping

### DIFF
--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -30,6 +30,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Skip pnpm's dependency status check which fails on @parcel/watcher build scripts
+      PNPM_SKIP_DEPS_STATUS_CHECK: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -30,9 +30,6 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # Skip pnpm's dependency status check which fails on @parcel/watcher build scripts
-      PNPM_SKIP_DEPS_STATUS_CHECK: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,6 +42,9 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Approve pnpm builds
+        run: pnpm config set strict-dep-builds false --location project
 
       - name: Resolve DMV branch for preview
         id: dmv

--- a/.github/workflows/deploy-to-firebase.yml
+++ b/.github/workflows/deploy-to-firebase.yml
@@ -43,8 +43,10 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - name: Approve pnpm builds
-        run: pnpm config set strict-dep-builds false --location project
+      - name: Disable strict dep builds check globally
+        run: |
+          pnpm config set strict-dep-builds false --global
+          echo "strict-dep-builds=false" >> ~/.npmrc
 
       - name: Resolve DMV branch for preview
         id: dmv

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,7 @@ shamefully-hoist=true
 
 # react-scripts 5 peer dependency ranges are outdated.
 strict-peer-dependencies=false
+
+# pnpm 11+ requires explicit approval for build scripts from dependencies.
+# Allow @parcel/watcher which is needed by the build process.
+onlyBuiltDependencies[]=@parcel/watcher

--- a/.npmrc
+++ b/.npmrc
@@ -5,5 +5,5 @@ shamefully-hoist=true
 strict-peer-dependencies=false
 
 # pnpm 11+ requires explicit approval for build scripts from dependencies.
-# Allow @parcel/watcher which is needed by the build process.
-onlyBuiltDependencies[]=@parcel/watcher
+# Disable strict dependency build checking to avoid CI failures.
+strict-dep-builds=false

--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ Custom selections are stored in `localStorage`, re-apply the current Bearer toke
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md#runtime-server-selection-header-button) for details.
 
+#### Runtime OIDC Configuration
+
+When `enableServerSelection` is enabled, users can also configure OIDC authentication settings at runtime through the server selection modal. This allows connecting to servers that require different authentication providers without redeploying the application.
+
+To use a custom OIDC provider, enter a JSON configuration in the OIDC config field:
+
+```json
+{
+  "authority": "https://accounts.google.com",
+  "clientId": "your-client-id.apps.googleusercontent.com",
+  "scope": "email profile openid https://www.googleapis.com/auth/cloud-healthcare",
+  "grantType": "implicit"
+}
+```
+
+Required fields: `authority`, `clientId`, `scope`
+
+Optional fields: `grantType`, `authorizationEndpoint`, `endSessionEndpoint`
+
+The OIDC configuration is cached in localStorage. If not provided, the deployment's default OIDC settings are used.
+
 ### Handling mixed content and HTTPS
 
 When deploying Slim with HTTPS, you may encounter mixed content scenarios where your PACS/VNA server returns HTTP URLs in its responses. This commonly occurs when:

--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ _Slim_ also supports interactive visualization of image annotations and analysis
 
 **Raster graphics:**
 
-- [DICOM Segmentation](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.51.html) instances that contain binary or fractional segmentation masks
+- [DICOM Segmentation](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.51.html) instances that contain binary or fractional segmentation masks, including TILED_SPARSE segmentations at non-standard resolution levels (e.g., segmentations created from rescaled image patches that don't match any pyramid level)
 - [DICOM Parametric Map](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_A.75.html) instances that contain saliency maps, attention maps, class activation maps, and similar derived images
 
 Fractional segmentations and parametric maps show an in-viewport color legend when at least one overlay is visible. The legend is collapsible and its per-item visibility toggles stay in sync with the switches in the right-hand panel.
+
+Clicking on a segment label in the right-hand panel zooms the viewport to that segment's bounding box, providing quick navigation to regions of interest.
 
 | | DICOM IOD |
 | :-: | :-------- |

--- a/package.json
+++ b/package.json
@@ -83,8 +83,5 @@
     "react-test-renderer": "^18.2.0",
     "sonarqube-scanner": "^4.3.0",
     "typescript": "^4.7.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["@parcel/watcher"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
     "react-test-renderer": "^18.2.0",
     "sonarqube-scanner": "^4.3.0",
     "typescript": "^4.7.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@parcel/watcher"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ shamefullyHoist: true
 strictPeerDependencies: false
 
 allowBuilds:
+  '@parcel/watcher': true
   core-js: true
   core-js-pure: true
   dicom-microscopy-viewer: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,11 @@ import {
 } from 'react-router-dom'
 
 import type AppConfig from './AppConfig'
-import type { ErrorMessageSettings, ServerSettings } from './AppConfig'
+import type {
+  ErrorMessageSettings,
+  OidcSettings,
+  ServerSettings,
+} from './AppConfig'
 import type { AuthManager, User } from './auth'
 import OidcManager from './auth/OidcManager'
 import AppLoading from './components/AppLoading'
@@ -200,7 +204,7 @@ interface AppState {
 }
 
 class App extends React.Component<AppProps, AppState> {
-  private readonly auth?: AuthManager
+  private auth?: AuthManager
   private reauthInProgress = false
   private unsubscribeAuthorization?: () => void
 
@@ -537,9 +541,34 @@ class App extends React.Component<AppProps, AppState> {
     }
   }
 
-  handleServerSelection = async ({ url }: { url: string }): Promise<void> => {
+  handleServerSelection = async ({
+    url,
+    oidc,
+  }: {
+    url: string
+    oidc?: OidcSettings
+  }): Promise<void> => {
     const trimmedUrl = url.trim()
     console.info('select DICOMweb server: ', trimmedUrl)
+
+    /** Handle OIDC configuration change */
+    if (oidc != null) {
+      console.info('applying custom OIDC configuration')
+      const { protocol, host } = window.location
+      const baseUri = `${protocol}//${host}`
+      const appUri = joinUrl(this.props.config.path, baseUri)
+      this.auth = new OidcManager(appUri, oidc)
+      /** Re-subscribe to authorization changes */
+      if (this.unsubscribeAuthorization != null) {
+        this.unsubscribeAuthorization()
+      }
+      this.unsubscribeAuthorization = this.auth.onAuthorizationChange(
+        (authorization) => {
+          this.applyAuthorization(authorization)
+        },
+      )
+    }
+
     if (
       trimmedUrl === '' ||
       window.localStorage.getItem('slim_server_selection_mode') === 'default'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -759,7 +759,7 @@ class App extends React.Component<AppProps, AppState> {
    * Parses cached OIDC config from localStorage.
    * Handles both JSON and JavaScript object notation (unquoted keys).
    */
-  private parseCachedOidcConfig(): OidcSettings | undefined {
+  private static parseCachedOidcConfig(): OidcSettings | undefined {
     const cachedOidcConfig = window.localStorage.getItem('slim_oidc_config')
     if (cachedOidcConfig == null || cachedOidcConfig.trim() === '') {
       return undefined
@@ -794,7 +794,7 @@ class App extends React.Component<AppProps, AppState> {
 
   componentDidMount(): void {
     /** Restore cached OIDC config and server selection if they exist */
-    const cachedOidcConfig = this.parseCachedOidcConfig()
+    const cachedOidcConfig = App.parseCachedOidcConfig()
     const cachedServerUrl = window.localStorage.getItem('slim_selected_server')
     const cachedMode = window.localStorage.getItem('slim_server_selection_mode')
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -755,16 +755,72 @@ class App extends React.Component<AppProps, AppState> {
     }
   }
 
+  /**
+   * Parses cached OIDC config from localStorage.
+   * Handles both JSON and JavaScript object notation (unquoted keys).
+   */
+  private parseCachedOidcConfig(): OidcSettings | undefined {
+    const cachedOidcConfig = window.localStorage.getItem('slim_oidc_config')
+    if (cachedOidcConfig == null || cachedOidcConfig.trim() === '') {
+      return undefined
+    }
+    try {
+      /** Convert JS object notation to JSON (quote unquoted keys) */
+      const normalized = cachedOidcConfig
+        .trim()
+        .replace(/([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g, '$1"$2"$3')
+      const parsed = JSON.parse(normalized)
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        typeof parsed.authority === 'string' &&
+        typeof parsed.clientId === 'string' &&
+        typeof parsed.scope === 'string'
+      ) {
+        return {
+          authority: parsed.authority,
+          clientId: parsed.clientId,
+          scope: parsed.scope,
+          grantType: parsed.grantType,
+          authorizationEndpoint: parsed.authorizationEndpoint,
+          endSessionEndpoint: parsed.endSessionEndpoint,
+        }
+      }
+    } catch {
+      /** Invalid format, ignore cached config */
+    }
+    return undefined
+  }
+
   componentDidMount(): void {
-    // Restore cached server selection if it exists
+    /** Restore cached OIDC config and server selection if they exist */
+    const cachedOidcConfig = this.parseCachedOidcConfig()
     const cachedServerUrl = window.localStorage.getItem('slim_selected_server')
+    const cachedMode = window.localStorage.getItem('slim_server_selection_mode')
+
+    /**
+     * Apply cached OIDC config if present (even for default server mode).
+     * This allows users to configure OIDC once and have it persist.
+     */
+    if (cachedOidcConfig != null) {
+      console.info('restoring cached OIDC configuration')
+      const { protocol, host } = window.location
+      const baseUri = `${protocol}//${host}`
+      const appUri = joinUrl(this.props.config.path, baseUri)
+      this.auth = new OidcManager(appUri, cachedOidcConfig)
+    }
+
     if (
+      cachedMode === 'custom' &&
       cachedServerUrl !== null &&
       cachedServerUrl !== undefined &&
       cachedServerUrl !== ''
     ) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.handleServerSelection({ url: cachedServerUrl })
+      this.handleServerSelection({
+        url: cachedServerUrl,
+        oidc: cachedOidcConfig,
+      })
     }
 
     if (this.auth != null) {

--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -13,7 +13,7 @@ export interface AttributeGroup {
 }
 
 interface DescriptionProps {
-  header?: string
+  header?: React.ReactNode
   icon?: React.ComponentType<Record<string, never>>
   attributes: Attribute[]
   selectable?: boolean

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import {
   BugOutlined,
   CheckOutlined,
   FileSearchOutlined,
+  InfoCircleOutlined,
   InfoOutlined,
   StopOutlined,
   UnorderedListOutlined,
@@ -27,6 +28,7 @@ import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 import appPackageJson from '../../package.json'
+import type { OidcSettings } from '../AppConfig'
 import type { User } from '../auth'
 import { SettingsButton } from '../contexts/SettingsContext'
 import type DicomWebManager from '../DicomWebManager'
@@ -43,6 +45,8 @@ import {
 import { normalizeServerUrl } from '../utils/url'
 import Button from './Button'
 import DicomTagBrowser from './DicomTagBrowser/DicomTagBrowser'
+
+const { TextArea } = Input
 
 const aboutModalCopyTooltips: [React.ReactNode, React.ReactNode] = [
   'Copy hash',
@@ -178,7 +182,13 @@ interface HeaderProps extends RouteComponentProps {
   clients?: { [key: string]: DicomWebManager }
   defaultClients?: { [key: string]: DicomWebManager }
   showWorklistButton: boolean
-  onServerSelection: ({ url }: { url: string }) => void
+  onServerSelection: ({
+    url,
+    oidc,
+  }: {
+    url: string
+    oidc?: OidcSettings
+  }) => void
   onUserLogout?: () => void
   showServerSelectionButton: boolean
 }
@@ -198,6 +208,10 @@ interface HeaderState {
   /** False only when both custom logo.svg and favicon.ico fail. */
   showLogo: boolean
   logoUrl: string
+  /** Optional OIDC config JSON string entered by user */
+  oidcConfigInput: string
+  /** Whether the OIDC config JSON is valid */
+  isOidcConfigValid: boolean
 }
 
 /**
@@ -212,6 +226,9 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const cachedMode = window.localStorage.getItem(
       'slim_server_selection_mode',
     ) as 'default' | 'custom' | null
+
+    const cachedOidcConfig =
+      window.localStorage.getItem('slim_oidc_config') ?? ''
 
     this.state = {
       errorObj: [],
@@ -229,6 +246,8 @@ class Header extends React.Component<HeaderProps, HeaderState> {
           : 'default',
       showLogo: true,
       logoUrl: `${process.env.PUBLIC_URL}/logo.svg`,
+      oidcConfigInput: cachedOidcConfig,
+      isOidcConfigValid: this.isValidOidcConfig(cachedOidcConfig),
     }
 
     const onErrorHandler = ({
@@ -339,6 +358,75 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     }
     const pathNorm = trimmedUrl.startsWith('/') ? trimmedUrl : `/${trimmedUrl}`
     return isGcpDicomStorePath(pathNorm)
+  }
+
+  /**
+   * Validates OIDC config JSON string.
+   * Returns true if empty (optional) or if valid JSON with required fields.
+   */
+  isValidOidcConfig = (jsonStr: string | null | undefined): boolean => {
+    if (jsonStr == null || jsonStr.trim() === '') {
+      return true
+    }
+    try {
+      const parsed = JSON.parse(jsonStr.trim())
+      return (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        typeof parsed.authority === 'string' &&
+        parsed.authority.length > 0 &&
+        typeof parsed.clientId === 'string' &&
+        parsed.clientId.length > 0 &&
+        typeof parsed.scope === 'string' &&
+        parsed.scope.length > 0
+      )
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Parses OIDC config JSON string into OidcSettings object.
+   * Returns undefined if empty or invalid.
+   */
+  parseOidcConfig = (
+    jsonStr: string | null | undefined,
+  ): OidcSettings | undefined => {
+    if (jsonStr == null || jsonStr.trim() === '') {
+      return undefined
+    }
+    try {
+      const parsed = JSON.parse(jsonStr.trim())
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        typeof parsed.authority === 'string' &&
+        typeof parsed.clientId === 'string' &&
+        typeof parsed.scope === 'string'
+      ) {
+        return {
+          authority: parsed.authority,
+          clientId: parsed.clientId,
+          scope: parsed.scope,
+          grantType: parsed.grantType,
+          authorizationEndpoint: parsed.authorizationEndpoint,
+          endSessionEndpoint: parsed.endSessionEndpoint,
+        }
+      }
+    } catch {
+      /** Invalid JSON */
+    }
+    return undefined
+  }
+
+  handleOidcConfigInput = (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+  ): void => {
+    const value = event.currentTarget.value
+    this.setState({
+      oidcConfigInput: value,
+      isOidcConfigValid: this.isValidOidcConfig(value),
+    })
   }
 
   static handleUserMenuButtonClick(e: React.SyntheticEvent): void {
@@ -633,6 +721,8 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const cachedServerUrl = window.localStorage
       .getItem('slim_selected_server')
       ?.trim()
+    const cachedOidcConfig =
+      window.localStorage.getItem('slim_oidc_config') ?? ''
     this.setState({
       serverSelectionMode:
         cachedServerUrl !== null &&
@@ -643,6 +733,8 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       selectedServerUrl: cachedServerUrl ?? undefined,
       isServerSelectionModalVisible: false,
       isServerSelectionDisabled: !this.isValidServerUrl(cachedServerUrl),
+      oidcConfigInput: cachedOidcConfig,
+      isOidcConfigValid: this.isValidOidcConfig(cachedOidcConfig),
     })
   }
 
@@ -657,8 +749,19 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       this.state.serverSelectionMode,
     )
 
+    /** Save OIDC config to localStorage */
+    const oidcConfig = this.parseOidcConfig(this.state.oidcConfigInput)
+    if (oidcConfig != null) {
+      window.localStorage.setItem(
+        'slim_oidc_config',
+        this.state.oidcConfigInput.trim(),
+      )
+    } else {
+      window.localStorage.removeItem('slim_oidc_config')
+    }
+
     if (this.state.serverSelectionMode === 'default') {
-      this.props.onServerSelection({ url: '' })
+      this.props.onServerSelection({ url: '', oidc: oidcConfig })
       this.setState({
         isServerSelectionModalVisible: false,
         isServerSelectionDisabled: false,
@@ -672,7 +775,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     if (url !== null && url !== undefined && url !== '') {
       if (this.isValidServerUrl(url)) {
         resolvedUrl = normalizeServerUrl(url)
-        this.props.onServerSelection({ url: resolvedUrl })
+        this.props.onServerSelection({ url: resolvedUrl, oidc: oidcConfig })
         closeModal = true
       }
     }
@@ -875,6 +978,63 @@ class Header extends React.Component<HeaderProps, HeaderState> {
               />
             </Tooltip>
           )}
+
+          <div style={{ marginTop: '16px' }}>
+            <Typography.Text>
+              OIDC Configuration (optional)
+              <Tooltip
+                title={
+                  <div
+                    style={{
+                      whiteSpace: 'pre-wrap',
+                      fontFamily: 'monospace',
+                      fontSize: '11px',
+                    }}
+                  >
+                    {`Example JSON format:
+{
+  "authority": "https://accounts.google.com",
+  "clientId": "your-client-id.apps.googleusercontent.com",
+  "scope": "email profile openid https://www.googleapis.com/auth/cloud-healthcare",
+  "grantType": "implicit"
+}`}
+                  </div>
+                }
+                overlayStyle={{ maxWidth: '450px' }}
+              >
+                <InfoCircleOutlined
+                  style={{
+                    marginLeft: '8px',
+                    color: 'rgba(0,0,0,.45)',
+                    cursor: 'help',
+                  }}
+                />
+              </Tooltip>
+            </Typography.Text>
+            <TextArea
+              placeholder='{"authority": "https://...", "clientId": "...", "scope": "..."}'
+              value={this.state.oidcConfigInput}
+              onChange={this.handleOidcConfigInput}
+              rows={4}
+              style={{
+                marginTop: '8px',
+                fontFamily: 'monospace',
+                fontSize: '12px',
+                borderColor:
+                  this.state.oidcConfigInput.trim() !== '' &&
+                  !this.state.isOidcConfigValid
+                    ? '#ff4d4f'
+                    : undefined,
+              }}
+            />
+            {this.state.oidcConfigInput.trim() !== '' &&
+              !this.state.isOidcConfigValid && (
+                <Typography.Text type="danger" style={{ fontSize: '12px' }}>
+                  Invalid JSON format. Required fields: authority, clientId,
+                  scope
+                </Typography.Text>
+              )}
+          </div>
         </Modal>
       </>
     )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -361,15 +361,25 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   /**
-   * Validates OIDC config JSON string.
-   * Returns true if empty (optional) or if valid JSON with required fields.
+   * Converts JavaScript object notation to valid JSON by quoting unquoted keys.
+   * Handles cases like { authority: "value" } -> { "authority": "value" }
+   */
+  normalizeToJson = (str: string): string => {
+    /** Match unquoted keys followed by colon */
+    return str.replace(/([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g, '$1"$2"$3')
+  }
+
+  /**
+   * Validates OIDC config string (JSON or JS object notation).
+   * Returns true if empty (optional) or if valid with required fields.
    */
   isValidOidcConfig = (jsonStr: string | null | undefined): boolean => {
     if (jsonStr == null || jsonStr.trim() === '') {
       return true
     }
     try {
-      const parsed = JSON.parse(jsonStr.trim())
+      const normalized = this.normalizeToJson(jsonStr.trim())
+      const parsed = JSON.parse(normalized)
       return (
         typeof parsed === 'object' &&
         parsed !== null &&
@@ -386,7 +396,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   /**
-   * Parses OIDC config JSON string into OidcSettings object.
+   * Parses OIDC config string (JSON or JS object notation) into OidcSettings.
    * Returns undefined if empty or invalid.
    */
   parseOidcConfig = (
@@ -396,7 +406,8 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       return undefined
     }
     try {
-      const parsed = JSON.parse(jsonStr.trim())
+      const normalized = this.normalizeToJson(jsonStr.trim())
+      const parsed = JSON.parse(normalized)
       if (
         typeof parsed === 'object' &&
         parsed !== null &&
@@ -414,7 +425,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
         }
       }
     } catch {
-      /** Invalid JSON */
+      /** Invalid format */
     }
     return undefined
   }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -247,7 +247,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       showLogo: true,
       logoUrl: `${process.env.PUBLIC_URL}/logo.svg`,
       oidcConfigInput: cachedOidcConfig,
-      isOidcConfigValid: this.isValidOidcConfig(cachedOidcConfig),
+      isOidcConfigValid: Header.isValidOidcConfig(cachedOidcConfig),
     }
 
     const onErrorHandler = ({
@@ -373,7 +373,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
    * Validates OIDC config string (JSON or JS object notation).
    * Returns true if empty (optional) or if valid with required fields.
    */
-  isValidOidcConfig = (jsonStr: string | null | undefined): boolean => {
+  static isValidOidcConfig(jsonStr: string | null | undefined): boolean {
     if (jsonStr == null || jsonStr.trim() === '') {
       return true
     }
@@ -399,9 +399,9 @@ class Header extends React.Component<HeaderProps, HeaderState> {
    * Parses OIDC config string (JSON or JS object notation) into OidcSettings.
    * Returns undefined if empty or invalid.
    */
-  parseOidcConfig = (
+  static parseOidcConfig(
     jsonStr: string | null | undefined,
-  ): OidcSettings | undefined => {
+  ): OidcSettings | undefined {
     if (jsonStr == null || jsonStr.trim() === '') {
       return undefined
     }
@@ -436,7 +436,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const value = event.currentTarget.value
     this.setState({
       oidcConfigInput: value,
-      isOidcConfigValid: this.isValidOidcConfig(value),
+      isOidcConfigValid: Header.isValidOidcConfig(value),
     })
   }
 
@@ -745,7 +745,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       isServerSelectionModalVisible: false,
       isServerSelectionDisabled: !this.isValidServerUrl(cachedServerUrl),
       oidcConfigInput: cachedOidcConfig,
-      isOidcConfigValid: this.isValidOidcConfig(cachedOidcConfig),
+      isOidcConfigValid: Header.isValidOidcConfig(cachedOidcConfig),
     })
   }
 
@@ -761,7 +761,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     )
 
     /** Save OIDC config to localStorage */
-    const oidcConfig = this.parseOidcConfig(this.state.oidcConfigInput)
+    const oidcConfig = Header.parseOidcConfig(this.state.oidcConfigInput)
     if (oidcConfig != null) {
       window.localStorage.setItem(
         'slim_oidc_config',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -364,7 +364,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
    * Converts JavaScript object notation to valid JSON by quoting unquoted keys.
    * Handles cases like { authority: "value" } -> { "authority": "value" }
    */
-  normalizeToJson = (str: string): string => {
+  static normalizeToJson(str: string): string {
     /** Match unquoted keys followed by colon */
     return str.replace(/([{,]\s*)([a-zA-Z_][a-zA-Z0-9_]*)(\s*:)/g, '$1"$2"$3')
   }
@@ -378,7 +378,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       return true
     }
     try {
-      const normalized = this.normalizeToJson(jsonStr.trim())
+      const normalized = Header.normalizeToJson(jsonStr.trim())
       const parsed = JSON.parse(normalized)
       return (
         typeof parsed === 'object' &&
@@ -406,7 +406,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       return undefined
     }
     try {
-      const normalized = this.normalizeToJson(jsonStr.trim())
+      const normalized = Header.normalizeToJson(jsonStr.trim())
       const parsed = JSON.parse(normalized)
       if (
         typeof parsed === 'object' &&

--- a/src/components/SegmentItem.tsx
+++ b/src/components/SegmentItem.tsx
@@ -180,7 +180,7 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
       metadata,
       onVisibilityChange,
       onStyleChange,
-      onClick,
+      onClick: _onClick,
       ...otherProps
     } = this.props
     return (

--- a/src/components/SegmentItem.tsx
+++ b/src/components/SegmentItem.tsx
@@ -34,6 +34,7 @@ interface SegmentItemProps {
       color?: number[]
     }
   }) => void
+  onClick: (segmentUID: string) => void
 }
 
 interface SegmentItemState {
@@ -111,6 +112,10 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
     }
   }
 
+  handleClick = (): void => {
+    this.props.onClick(this.props.segment.uid)
+  }
+
   render(): React.ReactNode {
     const attributes: Array<{ name: string; value: string }> = [
       {
@@ -175,6 +180,7 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
       metadata,
       onVisibilityChange,
       onStyleChange,
+      onClick,
       ...otherProps
     } = this.props
     return (
@@ -223,14 +229,26 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
               )}
             </Space>
           </div>
-          <div style={{ flex: 1 }}>
+          <button
+            type="button"
+            style={{
+              flex: 1,
+              cursor: 'pointer',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              textAlign: 'left',
+            }}
+            onClick={this.handleClick}
+            title="Click to zoom to segment"
+          >
             <Description
               header={this.props.segment.label}
               attributes={attributes}
               selectable
               hasLongValues
             />
-          </div>
+          </button>
         </Space>
       </Menu.Item>
     )

--- a/src/components/SegmentItem.tsx
+++ b/src/components/SegmentItem.tsx
@@ -1,5 +1,5 @@
 import { SettingOutlined } from '@ant-design/icons'
-import { Button, Divider, Menu, Popover, Space, Switch } from 'antd'
+import { Button, Divider, Menu, Popover, Space, Switch, Tag } from 'antd'
 // skipcq: JS-C1003
 import type * as dmv from 'dicom-microscopy-viewer'
 import React from 'react'
@@ -53,7 +53,7 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
     super(props)
 
     /** Initialize with default color if not provided */
-    const defaultColor = this.props.defaultStyle.color ?? [255, 255, 0] // Default yellow
+    const defaultColor = this.props.defaultStyle.color ?? [255, 255, 0]
     this.state = {
       isVisible: this.props.isVisible,
       currentStyle: {
@@ -67,6 +67,9 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
     checked: boolean,
     _event: React.MouseEvent<HTMLButtonElement>,
   ): void => {
+    if (this.props.segment.isAbsent) {
+      return
+    }
     this.props.onVisibilityChange({
       segmentUID: this.props.segment.uid,
       isVisible: checked,
@@ -113,10 +116,14 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
   }
 
   handleClick = (): void => {
+    if (this.props.segment.isAbsent) {
+      return
+    }
     this.props.onClick(this.props.segment.uid)
   }
 
   render(): React.ReactNode {
+    const isAbsent = this.props.segment.isAbsent === true
     const attributes: Array<{ name: string; value: string }> = [
       {
         name: 'Property Type',
@@ -142,7 +149,6 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
       | undefined
     const segmentationType = getSegmentationType(segmentationMetadata)
 
-    // Add SegmentationType from metadata if available
     if (segmentationMetadata?.SegmentationType !== undefined) {
       attributes.push({
         name: 'Segmentation Type',
@@ -195,9 +201,15 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
               <Switch
                 size="small"
                 onChange={this.handleVisibilityChange}
-                checked={this.props.isVisible}
+                checked={!isAbsent && this.props.isVisible}
+                disabled={isAbsent}
                 checkedChildren={<FaEye />}
                 unCheckedChildren={<FaEyeSlash />}
+                title={
+                  isAbsent
+                    ? 'Segment has no pixel data'
+                    : 'Toggle segment visibility'
+                }
               />
               <Popover
                 placement="left"
@@ -209,10 +221,10 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
                   type="primary"
                   shape="circle"
                   icon={<SettingOutlined />}
+                  disabled={isAbsent}
                 />
               </Popover>
-              {/* Color indicator - only show for non-fractional segmentation */}
-              {segmentationType !== 'FRACTIONAL' && (
+              {segmentationType !== 'FRACTIONAL' && !isAbsent && (
                 <div
                   style={{
                     width: '20px',
@@ -233,21 +245,37 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
             type="button"
             style={{
               flex: 1,
-              cursor: 'pointer',
+              cursor: isAbsent ? 'default' : 'pointer',
               background: 'none',
               border: 'none',
               padding: 0,
               textAlign: 'left',
+              opacity: isAbsent ? 0.75 : 1,
             }}
             onClick={this.handleClick}
-            title="Click to zoom to segment"
+            disabled={isAbsent}
+            title={
+              isAbsent
+                ? 'Segment is absent (no pixel data found)'
+                : 'Click to zoom to segment'
+            }
           >
-            <Description
-              header={this.props.segment.label}
-              attributes={attributes}
-              selectable
-              hasLongValues
-            />
+            <Space align="start" size={8}>
+              <Description
+                header={this.props.segment.label}
+                attributes={attributes}
+                selectable={!isAbsent}
+                hasLongValues
+              />
+              {isAbsent && (
+                <Tag
+                  color="default"
+                  title="Listed in Segment Sequence but no frames contain this segment"
+                >
+                  Absent
+                </Tag>
+              )}
+            </Space>
           </button>
         </Space>
       </Menu.Item>

--- a/src/components/SegmentItem.tsx
+++ b/src/components/SegmentItem.tsx
@@ -245,6 +245,7 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
             type="button"
             style={{
               flex: 1,
+              minWidth: 0,
               cursor: isAbsent ? 'default' : 'pointer',
               background: 'none',
               border: 'none',
@@ -260,22 +261,29 @@ class SegmentItem extends React.Component<SegmentItemProps, SegmentItemState> {
                 : 'Click to zoom to segment'
             }
           >
-            <Space align="start" size={8}>
-              <Description
-                header={this.props.segment.label}
-                attributes={attributes}
-                selectable={!isAbsent}
-                hasLongValues
-              />
-              {isAbsent && (
-                <Tag
-                  color="default"
-                  title="Listed in Segment Sequence but no frames contain this segment"
-                >
-                  Absent
-                </Tag>
-              )}
-            </Space>
+            <Description
+              header={
+                isAbsent ? (
+                  <div
+                    style={{ display: 'flex', flexDirection: 'column', gap: 4 }}
+                  >
+                    <span>{this.props.segment.label}</span>
+                    <Tag
+                      color="default"
+                      style={{ margin: 0, alignSelf: 'flex-start' }}
+                      title="Listed in Segment Sequence but no frames contain this segment"
+                    >
+                      Absent
+                    </Tag>
+                  </div>
+                ) : (
+                  this.props.segment.label
+                )
+              }
+              attributes={attributes}
+              selectable={!isAbsent}
+              hasLongValues
+            />
           </button>
         </Space>
       </Menu.Item>

--- a/src/components/SegmentList.tsx
+++ b/src/components/SegmentList.tsx
@@ -35,6 +35,7 @@ interface SegmentListProps {
       color?: number[]
     }
   }) => void
+  onSegmentClick: (segmentUID: string) => void
 }
 
 /**
@@ -75,6 +76,7 @@ class SegmentList extends React.Component<
           defaultStyle={this.props.defaultSegmentStyles[uid]}
           onVisibilityChange={this.props.onSegmentVisibilityChange}
           onStyleChange={this.props.onSegmentStyleChange}
+          onClick={this.props.onSegmentClick}
         />
       )
     })

--- a/src/components/SegmentList.tsx
+++ b/src/components/SegmentList.tsx
@@ -48,6 +48,9 @@ class SegmentList extends React.Component<
   handleVisibilityChange = (checked: boolean): void => {
     if (checked) {
       this.props.segments.forEach((segment) => {
+        if (segment.isAbsent) {
+          return
+        }
         this.props.onSegmentVisibilityChange({
           segmentUID: segment.uid,
           isVisible: checked,

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -3102,6 +3102,10 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
     }
   }
 
+  handleSegmentClick = (segmentUID: string): void => {
+    this.volumeViewer.zoomToSegment(segmentUID)
+  }
+
   /**
    * Handle change of segment style.
    */
@@ -4288,6 +4292,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
               visibleSegmentUIDs={this.state.visibleSegmentUIDs}
               onSegmentVisibilityChange={this.handleSegmentVisibilityChange}
               onSegmentStyleChange={this.handleSegmentStyleChange}
+              onSegmentClick={this.handleSegmentClick}
             />
           )}
         </Menu.SubMenu>

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -841,6 +841,12 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
        */
       const shownSegmentUIDs: string[] = []
       matchingSegments.forEach((segment) => {
+        if (segment.isAbsent) {
+          logger.debug(
+            `auto-load Segmentation: skipping absent segment "${segment.uid}"`,
+          )
+          return
+        }
         try {
           this.volumeViewer.showSegment(segment.uid)
           shownSegmentUIDs.push(segment.uid)
@@ -3082,6 +3088,13 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
     segmentUID: string
     isVisible: boolean
   }): void => {
+    const segment = this.volumeViewer
+      .getAllSegments()
+      .find((item) => item.uid === segmentUID)
+    if (segment?.isAbsent) {
+      logger.debug(`ignore visibility change for absent segment ${segmentUID}`)
+      return
+    }
     logger.log(`change visibility of segment ${segmentUID}`)
     if (isVisible) {
       logger.log(`show segment ${segmentUID}`)
@@ -3103,6 +3116,12 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
   }
 
   handleSegmentClick = (segmentUID: string): void => {
+    const segment = this.volumeViewer
+      .getAllSegments()
+      .find((item) => item.uid === segmentUID)
+    if (segment?.isAbsent) {
+      return
+    }
     this.volumeViewer.zoomToSegment(segmentUID)
   }
 

--- a/types/dicom-microscopy-viewer/index.d.ts
+++ b/types/dicom-microscopy-viewer/index.d.ts
@@ -156,9 +156,11 @@ declare module 'dicom-microscopy-viewer' {
         segmentUID: string,
         styleOptions?: {
           opacity?: number
-        }
+        },
+        shouldZoomIn?: boolean
       ): void
       hideSegment (segmentUID: string): void
+      zoomToSegment (segmentUID: string): void
       setSegmentStyle (
         segmentUID: string,
         styleOptions: {

--- a/types/dicom-microscopy-viewer/index.d.ts
+++ b/types/dicom-microscopy-viewer/index.d.ts
@@ -414,6 +414,7 @@ declare module 'dicom-microscopy-viewer' {
       studyInstanceUID: string
       seriesInstanceUID: string
       sopInstanceUIDs: string[]
+      isAbsent?: boolean
     }
 
     export class Segment {
@@ -428,6 +429,8 @@ declare module 'dicom-microscopy-viewer' {
       get studyInstanceUID (): string
       get seriesInstanceUID (): string
       get sopInstanceUIDs (): string[]
+      /** True when Segment Sequence lists the segment but no frames exist. */
+      get isAbsent (): boolean
     }
 
   }


### PR DESCRIPTION
dmv-branch: perf/tiled-sparse-dead-tiles

**Paired DMV PR:** https://github.com/ImagingDataCommons/dicom-microscopy-viewer/pull/284

## Summary

Forked from #429 (`feat/segment-click-to-zoom`) so that PR can stay untouched as a rollback/compare pair.

This Slim branch is the pairing vehicle for the DMV dead-tile performance work. App behavior matches #429 (click-to-zoom, absent badges, optional OIDC); Firebase preview should link DMV `perf/tiled-sparse-dead-tiles` via `dmv-branch`.

No Slim tile-pipeline changes — the performance fix lives in DMV (#284).

## Test plan

- [ ] Firebase preview builds and links DMV `perf/tiled-sparse-dead-tiles`
- [ ] PanopTILs / sparse non-matching SEGs: toggle multiple segments at overview without severe jank
- [ ] Click-to-zoom, absent segment badge, and visibility toggles still work
- [ ] Matching-level / TILED_FULL segmentations still render correctly
- [ ] Compare against #429 if needed; leave #429 open until a pair is chosen to merge
